### PR TITLE
ADA-5487: Port minor spec fixes from data repo

### DIFF
--- a/banking.yaml
+++ b/banking.yaml
@@ -156,7 +156,7 @@ paths:
           - Execution date/time if available, then
           - A reasonable date/time nominated by the data holder using internal data structures
         - For transaction amounts it should be assumed that a negative value indicates a reduction of the available balance on the account while a positive value indicates an increase in the available balance on the account
-        - For aggregated transactions (ie. groups of sub transactions reported as a single entry for the account) only the aggregated information, with as much consistent information accross the subsidiary transactions as possible, is required to be shared
+        - For aggregated transactions (ie. groups of sub transactions reported as a single entry for the account) only the aggregated information, with as much consistent information across the subsidiary transactions as possible, is required to be shared
       operationId: getAccountTransactions
       parameters:
         - $ref: '#/components/parameters/RequestPathCdrArrangementId'

--- a/data.yaml
+++ b/data.yaml
@@ -205,7 +205,7 @@ paths:
   /data/banking/products:
     get:
       security:
-        - bearerAuth: []
+        - bearerAuth: [ 'adr:banking:read' ]
       tags:
         - Banking
       summary: Get Banking Products


### PR DESCRIPTION
## Summary
- `data.yaml`: updated `/data/banking/products` security scope from `bearerAuth: []` to `bearerAuth: ['adr:banking:read']` (ADA-5456)
- `banking.yaml`: fixed typo `accross` → `across` in transaction description

## Notes
No new public APIs added. Other changes from the data repo (email update, enum additions, schema removals, allOf refactors) were already reflected in api-specs.