### PR TITLE
ADA-5492: Draft banking v3.0.0 + data v2.0.0 spec changes

### DIFF
--- a/draft/banking.yaml
+++ b/draft/banking.yaml
@@ -1,0 +1,3457 @@
+openapi: 3.0.1
+info:
+  title: Adatree ADR Platform Open Banking API
+  description: |-
+    Adatree's Accredited Data Recipient (ADR) Platform Open Banking API definition. API payloads conform to the Consumer Data Right Data Standard 1.5.1.
+    Payloads are sample payloads to represent the types of data to which the CDR regime gives access. Adatree's simplified API makes it easier for you to access the CDR ecosystem, while maintaining the high security standards implemented by the regime. It also keeps the data in the original, open source, CDR format to avoid lock-in to a proprietary format.
+  contact:
+    name: Adatree Pty Ltd
+    url: https://adatree.com.au
+    email: support@adatree.com.au
+  version: "3.0.0"
+servers:
+  - url: https://cdr-insights-prod.api.adatree.com.au
+security:
+  - bearerAuth: [ 'adr:banking:read' ]
+paths:
+  /adr/banking/arrangements/{cdrArrangementId}/accounts:
+    get:
+      tags:
+        - Accounts
+      summary: Get Accounts under cdr arrangement id
+      description: Obtain a list of accounts
+      operationId: getAccounts
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - $ref: '#/components/parameters/ParamProductCategory'
+        - $ref: '#/components/parameters/ParamAccountOpenStatus'
+        - $ref: '#/components/parameters/ParamAccountIsOwned'
+        - $ref: '#/components/parameters/ParamPage'
+        - $ref: '#/components/parameters/ParamPageSize'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: A list of accounts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseBankingAccountList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/banking/arrangements/{cdrArrangementId}/accounts/balances:
+    get:
+      tags:
+        - AccountsBalances
+      summary: Get Bulk Balances
+      description: Obtain balances for multiple, filtered accounts
+      operationId: getBalancesForAccounts
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - $ref: '#/components/parameters/ParamAccountIds'
+        - $ref: '#/components/parameters/ParamProductCategory'
+        - $ref: '#/components/parameters/ParamAccountOpenStatus'
+        - $ref: '#/components/parameters/ParamAccountIsOwned'
+        - $ref: '#/components/parameters/ParamPage'
+        - $ref: '#/components/parameters/ParamPageSize'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: A list of account balances
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseBankingAccountsBalanceList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        422:
+          description: The request was well formed but was unable to be processed
+            due to business logic specific to the request.  For this API a 422 response
+            must be given if any of the account IDs provided are invalid for the consent
+            context
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList_errors'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/banking/arrangements/{cdrArrangementId}/accounts/{accountId}/balance:
+    get:
+      tags:
+        - AccountsBalance
+      summary: Get Account Balance
+      description: Obtain the balance for a single specified account
+      operationId: getAccountBalance
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - $ref: '#/components/parameters/RequestPathAccountId'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseBankingAccountsBalanceById'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/banking/arrangements/{cdrArrangementId}/accounts/{accountId}:
+    get:
+      tags:
+        - Accounts
+      summary: Get Account Detail
+      description: Obtain detailed information on a single account
+      operationId: getAccountDetail
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - $ref: '#/components/parameters/RequestPathAccountId'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseBankingAccountById'
+  /adr/banking/arrangements/{cdrArrangementId}/accounts/{accountId}/transactions:
+    get:
+      tags:
+        - AccountTransactions
+      summary: Get Transactions For Account
+      description: |-
+        Obtain transactions for a specific account.
+        Some general notes that apply to all end points that retrieve transactions:
+        - Where multiple transactions are returned, transactions should be ordered according to effective date in descending order
+        - As the date and time for a transaction can alter depending on status and transaction type two separate date/times are included in the payload. There are still some scenarios where neither of these time stamps is available. For the purpose of filtering and ordering it is expected that the data holder will use the effective date/time which will be defined as:
+          - Posted date/time if available, then
+          - Execution date/time if available, then
+          - A reasonable date/time nominated by the data holder using internal data structures
+        - For transaction amounts it should be assumed that a negative value indicates a reduction of the available balance on the account while a positive value indicates an increase in the available balance on the account
+        - For aggregated transactions (ie. groups of sub transactions reported as a single entry for the account) only the aggregated information, with as much consistent information across the subsidiary transactions as possible, is required to be shared
+      operationId: getAccountTransactions
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - $ref: '#/components/parameters/RequestPathAccountIdPreviouslyListed'
+        - $ref: '#/components/parameters/ParamTransactionOldestTime'
+        - $ref: '#/components/parameters/ParamTransactionNewestTime'
+        - $ref: '#/components/parameters/ParamTransactionMinAmount'
+        - $ref: '#/components/parameters/ParamTransactionMaxAmount'
+        - $ref: '#/components/parameters/ParamTransactionText'
+        - $ref: '#/components/parameters/ParamPage'
+        - $ref: '#/components/parameters/ParamPageSize'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ResponseBankingTransactionList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/banking/arrangements/{cdrArrangementId}/accounts/{accountId}/transactions/{transactionId}:
+    get:
+      tags:
+        - AccountTransactions
+      summary: Get Transaction Detail
+      description: Obtain detailed information on a transaction for a specific account
+      operationId: getTransactionDetail
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - $ref: '#/components/parameters/RequestPathAccountIdPreviouslyListed'
+        - name: transactionId
+          in: path
+          description: ID of the transaction obtained from a previous call to one of
+            the other transaction end points
+          required: true
+          schema:
+            type: string
+            x-cds-type: ASCIIString
+            example: e27f7698-814f-467f-8c65-ca9d59832ffd
+          x-cds-type: ASCIIString
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseBankingTransactionById'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/banking/arrangements/{cdrArrangementId}/accounts/{accountId}/direct-debits:
+    get:
+      tags:
+        - AccountDirectDebits
+      summary: Get Direct Debits For Account
+      description: Obtain direct debit authorisations for a specific account
+      operationId: getAccountDirectDebits
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - name: accountId
+          in: path
+          description: ID of the account to get direct debit authorisations for.  Must
+            have previously been returned by one of the account list end points.
+          required: true
+          schema:
+            type: string
+            x-cds-type: ASCIIString
+            example: d9e75179-104f-47cf-9d29-18284222bab0
+          x-cds-type: ASCIIString
+        - $ref: '#/components/parameters/ParamPage'
+        - $ref: '#/components/parameters/ParamPageSize'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseBankingDirectDebitAuthorisationList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/banking/arrangements/{cdrArrangementId}/accounts/direct-debits:
+    get:
+      tags:
+        - AccountsDirectDebits
+      summary: Get Bulk Direct Debits
+      description: Obtain direct debit authorisations for multiple, filtered accounts
+      operationId: getDirectDebitsForAccounts
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - $ref: '#/components/parameters/ParamAccountIds'
+        - $ref: '#/components/parameters/ParamProductCategory'
+        - $ref: '#/components/parameters/ParamAccountOpenStatus'
+        - $ref: '#/components/parameters/ParamAccountIsOwned'
+        - $ref: '#/components/parameters/ParamPage'
+        - $ref: '#/components/parameters/ParamPageSize'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseBankingDirectDebitAuthorisationList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        422:
+          description: The request was well formed but was unable to be processed
+            due to business logic specific to the request.  For this API a 422 response
+            must be given if any of the account IDs provided are invalid for the consent
+            context
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/banking/arrangements/{cdrArrangementId}/accounts/{accountId}/payments/scheduled:
+    get:
+      tags:
+        - AccountPaymentsScheduled
+      summary: Get Scheduled Payments for Account
+      description: Obtain scheduled, outgoing payments for a specific account
+      operationId: getAccountScheduledPayments
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - name: accountId
+          in: path
+          description: ID of the account to get scheduled payments for. Must have previously
+            been returned by one of the account list end points. The account specified
+            is the source account for the payment
+          required: true
+          schema:
+            type: string
+            x-cds-type: ASCIIString
+            example: d9e75179-104f-47cf-9d29-18284222bab0
+          x-cds-type: ASCIIString
+        - $ref: '#/components/parameters/ParamPage'
+        - $ref: '#/components/parameters/ParamPageSize'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseBankingScheduledPaymentsList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/banking/arrangements/{cdrArrangementId}/payments/scheduled:
+    get:
+      tags:
+        - PaymentsScheduled
+      summary: Get Scheduled Payments Bulk
+      description: Obtain scheduled payments for multiple, filtered accounts that
+        are the source of funds for the payments
+      operationId: getScheduledPaymentsForAccounts
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - $ref: '#/components/parameters/ParamAccountIds'
+        - $ref: '#/components/parameters/ParamProductCategory'
+        - $ref: '#/components/parameters/ParamAccountOpenStatus'
+        - $ref: '#/components/parameters/ParamAccountIsOwned'
+        - $ref: '#/components/parameters/ParamPage'
+        - $ref: '#/components/parameters/ParamPageSize'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseBankingScheduledPaymentsList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        422:
+          description: The request was well formed but was unable to be processed
+            due to business logic specific to the request.  For this API a 422 response
+            must be given if any of the account IDs provided are invalid for the consent
+            context
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/banking/arrangements/{cdrArrangementId}/payees:
+    get:
+      tags:
+        - Payees
+      summary: Get Payees
+      description: Obtain a list of pre-registered payees
+      operationId: getPayees
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - name: type
+          in: query
+          description: Filter on the payee type field.  In addition to normal type field
+            values, ALL can be specified to retrieve all payees.  If absent the assumed
+            value is ALL
+          schema:
+            type: string
+            default: ALL
+            example: BILLER
+            enum:
+              - BILLER
+              - DOMESTIC
+              - INTERNATIONAL
+              - ALL
+        - $ref: '#/components/parameters/ParamPage'
+        - $ref: '#/components/parameters/ParamPageSize'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseBankingPayeeList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/banking/arrangements/{cdrArrangementId}/payees/{payeeId}:
+    get:
+      tags:
+        - Payees
+      summary: Get Payee Detail
+      description: |-
+        Obtain detailed information on a single payee.
+
+        Note that the payee sub-structure should be selected to represent the payment destination only rather than any known characteristics of the payment recipient
+      operationId: getPayeeDetail
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - name: payeeId
+          in: path
+          description: The ID used to locate the details of a particular payee
+          required: true
+          schema:
+            type: string
+            x-cds-type: ASCIIString
+            example: d9e75179-104f-47cf-9d29-18284222bab0
+          x-cds-type: ASCIIString
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseBankingPayeeById'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/common/arrangements/{cdrArrangementId}/userinfo:
+    get:
+      tags:
+        - User Info
+      summary: Get user info under cdr arrangement id
+      description: Obtain the user info exposed by the data holder's identify provider
+      operationId: getUserinfo
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+      responses:
+        200:
+          description: User info
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserInfoByArrangementId'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        424:
+          $ref: '#/components/responses/424FailedDependency'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/common/arrangements/{cdrArrangementId}/customer:
+    get:
+      tags:
+        - Customers
+      summary: Get Customer
+      description: Obtain basic information on the customer that has authorised the
+        current session
+      operationId: getCustomer
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseCommonCustomer'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /adr/common/arrangements/{cdrArrangementId}/customer/detail:
+    get:
+      tags:
+        - Customers
+      summary: Get Customer Detail
+      description: Obtain detailed information on the authorised customer within the
+        current session.
+      operationId: getCustomerDetail
+      parameters:
+        - $ref: '#/components/parameters/RequestPathCdrArrangementId'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-auth-date'
+        - $ref: '#/components/parameters/RequestHeader_x-fapi-customer-ip-address'
+        - $ref: '#/components/parameters/RequestHeader_x-cds-client-headers'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseCommonCustomerDetail'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    UserInfoByArrangementId:
+      type: object
+      required:
+        - acr
+        - cdrArrangementId
+        - refreshTokenExpiresAt
+        - sharingExpiresAt
+        - sub
+        - name
+        - givenName
+        - familyName
+        - updatedAt
+      properties:
+        acr:
+          type: string
+          example: "urn:cds.au:cdr:2"
+          description: Authentication Context Class Reference. Contain an ordinal LoA value.
+          x-cds-type: ASCIIString
+        cdrArrangementId:
+          type: string
+          example: 979444dc-b692-4974-a194-bde1fc0505ff
+          description: A unique string representing a consent arrangement between a Data Recipient Software Product and Data Holder for a given consumer.
+          x-cds-type: ASCIIString
+        refreshTokenExpiresAt:
+          type: number
+          example: 1654669122
+          description: Indicates the date-time at which the most recently provided refresh token will expire.
+        sharingExpiresAt:
+          type: number
+          example: 1657261122
+          description: Indicates the date-time at which the current sharing arrangement will expire.
+        sub:
+          type: string
+          example: leVC9WDe0yOj31UyOoTr
+          description: Pairwise Pseudonymous Identifier (PPID) for the End-User at the Data Holder.
+          x-cds-type: ASCIIString
+        name:
+          type: string
+          example: "Jane Doe"
+          description: End-User's full name in displayable form including all name parts.
+          x-cds-type: ASCIIString
+        givenName:
+          type: string
+          example: "Jane"
+          description: Given name(s) or first name(s) of the End-User.
+          x-cds-type: ASCIIString
+        familyName:
+          type: string
+          example: "Doe"
+          description: Surname(s) or last name(s) of the End-User.
+          x-cds-type: ASCIIString
+        updatedAt:
+          type: number
+          example: 1654153174
+          description: Time the End-User's information was last updated. Its value is a JSON number representing the number of seconds from 1970-01-01T00:00:00Z to the UTC updatedAt time.
+        email:
+          type: string
+          example: "janedoe@example.com"
+          description: End-User's preferred e-mail address. Its value MUST conform to the [RFC5322] addr-spec syntax. The Data Recipient MUST NOT rely upon this value being unique, as discussed in Section 5.7 of [OIDC]
+        emailVerified:
+          type: boolean
+          example: true
+          description: True if the End-User's e-mail address has been verified; otherwise false. When this Claim Value is true, this means that the Data Holder took affirmative steps to ensure that this e-mail address was controlled by the End-User at the time the verification was performed. The means by which an e-mail address is verified is context-specific, and dependent upon the trust framework or contractual agreements within which the parties are operating.
+          x-cds-type: Boolean
+        phoneNumber:
+          type: string
+          example: "+61449555123"
+          description: End-User's preferred telephone number. [E.164] is RECOMMENDED as the format of this Claim, for example, +1 (425) 555-1212 or +56 (2) 687 2400. If the phone number contains an extension, it is RECOMMENDED that the extension be represented using the [RFC3966] extension syntax, for example, +1 (604) 555-1234;ext=5678.
+          x-cds-type: String
+        phoneNumberVerified:
+          type: boolean
+          example: true
+          description: True if the End-User's phone number has been verified; otherwise false. When this Claim Value is true, this means that the Data Holder took affirmative steps to ensure that this phone number was controlled by the End-User at the time the verification was performed. The means by which a phone number is verified is context- specific, and dependent upon the trust framework or contractual agreements within which the parties are operating. When true, the phone_number Claim MUST be in [E.164] format and any extensions MUST be represented in [RFC3966] format.
+          x-cds-type: Boolean
+        address:
+          $ref: '#/components/schemas/OidcAddress'
+        meta:
+          $ref: '#/components/schemas/Meta'
+    OidcAddress:
+      type: object
+      properties:
+        formatted:
+          type: string
+          example: "2067 Armbrester Drive Sydney NSW 2000 AU"
+          description: "The full mailing address, with multiple lines if necessary. Newlines can be represented either as a \r\n or as a \n."
+          x-cds-type: String
+        streetAddress:
+          type: string
+          example: "2067 Armbrester Drive"
+          description: "The street address component, which may include house number, stree name, post office box, and other multi-line information. Newlines can be represented either as a \r\n or as a \n."
+          x-cds-type: String
+        locality:
+          type: string
+          example: "Sydney"
+          description: "City or locality component."
+          x-cds-type: String
+        region:
+          type: string
+          example: "NSW"
+          description: "State, province, prefecture or region component."
+          x-cds-type: String
+        postalCode:
+          type: string
+          example: "2000"
+          description: "Zip code or postal code component."
+          x-cds-type: String
+        country:
+          type: string
+          example: "AU"
+          description: "Country name component."
+          x-cds-type: String
+    BankingProductFeature:
+      type: object
+      required:
+        - featureType
+      properties:
+        featureType:
+          type: string
+          description: The type of feature described
+          example: BONUS_REWARDS
+          enum:
+            - ADDITIONAL_CARDS
+            - BALANCE_TRANSFERS
+            - BILL_PAYMENT
+            - BONUS_REWARDS
+            - CARD_ACCESS
+            - CASHBACK_OFFER
+            - COMPLEMENTARY_PRODUCT_DISCOUNTS
+            - EXTRA_DOWN_PAYMENT
+            - DIGITAL_BANKING
+            - DIGITAL_WALLET
+            - DONATE_INTEREST
+            - EXTRA_REPAYMENTS
+            - FRAUD_PROTECTION
+            - FREE_TXNS
+            - FREE_TXNS_ALLOWANCE
+            - FUNDS_AVAILABLE_AFTER
+            - GUARANTOR
+            - INSURANCE
+            - INSTALMENT_PLAN
+            - INTEREST_FREE
+            - INTEREST_FREE_TRANSFERS
+            - LOYALTY_PROGRAM
+            - NOTIFICATIONS
+            - NPP_ENABLED
+            - NPP_PAYID
+            - OFFSET
+            - OTHER
+            - OVERDRAFT
+            - REDRAW
+            - RELATIONSHIP_MANAGEMENT
+            - UNLIMITED_TXNS
+        additionalValue:
+          type: string
+          description: Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
+          example: free mobile device screen smash insurance
+        additionalInfo:
+          type: string
+          description: Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
+          example: the best of a kind
+        additionalInfoUri:
+          type: string
+          description: Link to a web page with more information on this feature
+          example: https://productfeature.example.com.au
+          x-cds-type: URIString
+      x-conditional:
+        - additionalValue
+        - additionalInfo
+    BankingProductFee:
+      type: object
+      required:
+        - name
+        - feeType
+        - feeMethodUType
+      properties:
+        name:
+          type: string
+          description: Name of the fee.
+          example: account fee
+        feeType:
+          type: string
+          description: The type of fee.
+          example: PERIODIC
+          enum:
+            - CASH_ADVANCE
+            - DEPOSIT
+            - DISHONOUR
+            - ENQUIRY
+            - EVENT
+            - EXIT
+            - LATE_PAYMENT
+            - OTHER
+            - PAYMENT
+            - PERIODIC
+            - PURCHASE
+            - REPLACEMENT
+            - TRANSACTION
+            - UPFRONT
+            - UPFRONT_PER_PLAN
+            - VARIATION
+            - VARIABLE
+            - WITHDRAWAL
+        feeMethodUType:
+          type: string
+          description: Reference to the applicable fee charging method structure.
+          enum:
+            - fixedAmount
+            - rateBased
+            - variable
+        fixedAmount:
+          allOf:
+            - $ref: '#/components/schemas/BankingFeeAmount'
+        rateBased:
+          allOf:
+            - $ref: '#/components/schemas/BankingFeeRate'
+        variable:
+          allOf:
+            - $ref: '#/components/schemas/BankingFeeRange'
+        feeCap:
+          type: string
+          description: The cap amount if multiple occurrences of the fee are capped to a limit.
+          x-cds-type: AmountString
+        feeCapPeriod:
+          type: string
+          description: Specifies a duration over which multiple occurrences of the fee will be capped.
+          x-cds-type: ExternalRef
+        currency:
+          type: string
+          description: The currency the fee will be charged in. Assumes AUD if absent
+          example: AUD
+          x-cds-type: CurrencyString
+        additionalValue:
+          type: string
+          description: Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
+          example: additional info for bank account fee
+        additionalInfo:
+          type: string
+          description: Display text providing more information on the fee
+          example: additional info on the fee
+        additionalInfoUri:
+          type: string
+          description: Link to a web page with more information on this fee
+          example: https://bankfee.example.com.au
+          x-cds-type: URIString
+        discounts:
+          type: array
+          description: An optional list of discounts to this fee that may be available
+          items:
+            $ref: '#/components/schemas/BankingProductDiscount'
+      x-conditional:
+        - fixedAmount
+        - rateBased
+        - variable
+        - additionalValue
+        - additionalInfo
+    BankingFeeAmount:
+      type: object
+      required:
+        - amount
+      properties:
+        amount:
+          type: string
+          description: The specific amount charged for the fee each time it is incurred.
+          x-cds-type: AmountString
+    BankingFeeRate:
+      type: object
+      required:
+        - rateType
+        - rate
+      properties:
+        rateType:
+          type: string
+          description: Type of fee rate calculation.
+          enum:
+            - BALANCE
+            - INTEREST_ACCRUED
+            - TRANSACTION
+        rate:
+          type: string
+          description: The fee rate calculated according to the rateType.
+          x-cds-type: RateString
+        accrualFrequency:
+          type: string
+          description: The indicative frequency with which the fee is calculated on the account if applicable.
+          x-cds-type: ExternalRef
+        amountRange:
+          $ref: '#/components/schemas/BankingFeeRange'
+    BankingFeeRange:
+      type: object
+      description: A minimum or maximum fee amount where a specific fixed amount is not known until the fee is incurred.
+      properties:
+        feeMinimum:
+          type: string
+          description: The minimum fee that will be charged per occurrence.
+          x-cds-type: AmountString
+        feeMaximum:
+          type: string
+          description: The maximum fee that will be charged per occurrence.
+          x-cds-type: AmountString
+    BankingProductDiscount:
+      type: object
+      required:
+        - description
+        - discountType
+      properties:
+        description:
+          type: string
+          example: loyalty discount
+          description: Description of the discount
+        discountType:
+          type: string
+          example: ELIGIBILITY_ONLY
+          description: The type of discount. See the next section for an overview of valid values and their meaning
+          enum:
+            - BALANCE
+            - DEPOSITS
+            - ELIGIBILITY_ONLY
+            - FEE_CAP
+            - PAYMENTS
+        discountMethodUType:
+          type: string
+          description: Reference to the applicable fee discount method structure.
+          enum:
+            - fixedAmount
+            - rateBased
+        fixedAmount:
+          allOf:
+            - $ref: '#/components/schemas/BankingFeeDiscountAmount'
+        rateBased:
+          allOf:
+            - $ref: '#/components/schemas/BankingFeeDiscountRate'
+        additionalValue:
+          type: string
+          example: extra discount
+          description: Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
+        additionalInfo:
+          type: string
+          example: addition info for discount
+          description: Display text providing more information on the discount
+        additionalInfoUri:
+          type: string
+          example: https://productdiscount.example.com.au
+          description: Link to a web page with more information on this discount
+          x-cds-type: URIString
+        eligibility:
+          type: array
+          description: Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
+          items:
+            $ref: '#/components/schemas/BankingProductDiscountEligibility'
+      x-conditional:
+        - fixedAmount
+        - rateBased
+        - additionalValue
+        - eligibility
+    BankingFeeDiscountAmount:
+      type: object
+      required:
+        - amount
+      properties:
+        amount:
+          type: string
+          description: The specific amount discounted from the fee each time it is incurred.
+          x-cds-type: AmountString
+    BankingFeeDiscountRate:
+      type: object
+      required:
+        - rateType
+        - rate
+      properties:
+        rateType:
+          type: string
+          description: Type of fee rate discount calculation.
+          enum:
+            - BALANCE
+            - FEE
+            - INTEREST_ACCRUED
+            - TRANSACTION
+        rate:
+          type: string
+          description: The fee rate discount calculated according to the rateType.
+          x-cds-type: RateString
+        amountRange:
+          $ref: '#/components/schemas/BankingFeeDiscountRange'
+    BankingFeeDiscountRange:
+      type: object
+      description: A minimum or maximum fee discount amount where a specific fixed amount is not known until the fee is incurred.
+      properties:
+        discountMinimum:
+          type: string
+          description: The minimum fee discount that will be applied per occurrence.
+          x-cds-type: AmountString
+        discountMaximum:
+          type: string
+          description: The maximum fee discount that will be applied per occurrence.
+          x-cds-type: AmountString
+    BankingProductDiscountEligibility:
+      type: object
+      required:
+        - discountEligibilityType
+      properties:
+        discountEligibilityType:
+          type: string
+          example: "STAFF"
+          description: The type of the specific eligibility constraint for a discount
+          enum:
+            - BUSINESS
+            - EMPLOYMENT_STATUS
+            - INTRODUCTORY
+            - MAX_AGE
+            - MIN_AGE
+            - MIN_INCOME
+            - MIN_TURNOVER
+            - NATURAL_PERSON
+            - PENSION_RECIPIENT
+            - RESIDENCY_STATUS
+            - STAFF
+            - STUDENT
+            - OTHER
+        additionalValue:
+          type: string
+          example: additional value for discount eligibility
+          description: Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+        additionalInfo:
+          type: string
+          example: additional info for discount eligibility
+          description: Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+        additionalInfoUri:
+          type: string
+          example: https://discounteligibility.example.com.au
+          description: Link to a web page with more information on this eligibility constraint
+          x-cds-type: URIString
+      x-conditional:
+        - additionalInfo
+        - additionalValue
+    BankingProductDepositRate:
+      type: object
+      required:
+        - depositRateType
+        - rate
+      properties:
+        depositRateType:
+          type: string
+          example: FIXED
+          description: The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
+          enum:
+            - BONUS
+            - BUNDLE_BONUS
+            - FIXED
+            - FLOATING
+            - INTRODUCTORY
+            - MARKET_LINKED
+            - VARIABLE
+        rate:
+          type: string
+          example: 2.50
+          description: The rate to be applied
+          x-cds-type: RateString
+        calculationFrequency:
+          type: string
+          example: P1M
+          description: The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+          x-cds-type: ExternalRef
+        applicationType:
+          type: string
+          description: The method used to apply the calculated amount
+          enum:
+            - MATURITY
+            - PERIODIC
+            - UPFRONT
+        applicationFrequency:
+          type: string
+          example: P1M
+          description: The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+          x-cds-type: ExternalRef
+        tiers:
+          type: array
+          description: Rate tiers applicable for this rate
+          items:
+            $ref: '#/components/schemas/BankingProductRateTierV3'
+        applicabilityConditionList:
+          type: array
+          description: Applicability conditions for the rate
+          items:
+            $ref: '#/components/schemas/BankingProductRateCondition'
+        additionalValue:
+          type: string
+          example: additional value for deposit rate
+          description: Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
+        additionalInfo:
+          type: string
+          example: additional info for deposit rate
+          description: Display text providing more information on the rate
+        additionalInfoUri:
+          type: string
+          example: https://depositrate.example.com.au
+          description: Link to a web page with more information on this rate
+          x-cds-type: URIString
+      x-conditional:
+        - additionalValue
+    BankingProductLendingRateV2:
+      type: object
+      required:
+        - lendingRateType
+        - rate
+      properties:
+        lendingRateType:
+          type: string
+          description: The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
+          example: CASH_ADVANCE
+          enum:
+            - BALANCE_TRANSFER
+            - BUNDLE_DISCOUNT_FIXED
+            - BUNDLE_DISCOUNT_VARIABLE
+            - CASH_ADVANCE
+            - DISCOUNT
+            - FLOATING
+            - INTRODUCTORY
+            - MARKET_LINKED
+            - PENALTY
+            - PURCHASE
+            - VARIABLE
+            - FIXED
+        rate:
+          type: string
+          example: 3.99
+          description: The rate to be applied
+          x-cds-type: RateString
+        comparisonRate:
+          type: string
+          example: 4.99
+          description: A comparison rate equivalent for this rate
+          x-cds-type: RateString
+        calculationFrequency:
+          type: string
+          example: P1M
+          description: The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+          x-cds-type: ExternalRef
+        applicationType:
+          type: string
+          description: The method used to apply the calculated amount
+          enum:
+            - MATURITY
+            - PERIODIC
+            - UPFRONT
+        applicationFrequency:
+          type: string
+          example: P1M
+          description: The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+          x-cds-type: ExternalRef
+        interestPaymentDue:
+          type: string
+          example: IN_ARREARS
+          description: When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
+          enum:
+            - IN_ADVANCE
+            - IN_ARREARS
+        repaymentType:
+          type: string
+          example: INTEREST_ONLY
+          description: Options in place for repayments. If absent, the lending rate is applicable to all repayment types
+          enum:
+            - INTEREST_ONLY
+            - OTHER
+            - PRINCIPAL_AND_INTEREST
+            - UNCONSTRAINED
+        loanPurpose:
+          type: string
+          example: OWNER_OCCUPIED
+          description: The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
+          enum:
+            - OTHER
+            - OWNER_OCCUPIED
+            - INVESTMENT
+            - UNCONSTRAINED
+        tiers:
+          type: array
+          description: Rate tiers applicable for this rate
+          items:
+            $ref: '#/components/schemas/BankingProductRateTierV3'
+        applicabilityConditionList:
+          type: array
+          description: Applicability conditions for the rate
+          items:
+            $ref: '#/components/schemas/BankingProductRateCondition'
+        additionalValue:
+          type: string
+          example: additional value for lending
+          description: Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
+        additionalInfo:
+          type: string
+          example: additional info for lending
+          description: Display text providing more information on the rate.
+        additionalInfoUri:
+          type: string
+          example: https://lendingrate.example.com.au
+          description: Link to a web page with more information on this rate
+          x-cds-type: URIString
+      x-conditional:
+        - additionalValue
+    BankingProductRateTierV3:
+      type: object
+      required:
+        - name
+        - unitOfMeasure
+        - minimumValueString
+      properties:
+        name:
+          type: string
+          example: basic
+          description: A display name for the tier
+        unitOfMeasure:
+          type: string
+          example: MONTH
+          description: The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+          enum:
+            - DOLLAR
+            - PERCENT
+            - DAY
+            - MONTH
+        minimumValueString:
+          type: string
+          example: "1"
+          description: String representation of the lower bound of the tier
+        maximumValueString:
+          type: string
+          example: "3"
+          description: String representation of the upper bound of the tier
+        rateApplicationMethod:
+          type: string
+          description: The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+          example: PER_TIER
+          enum:
+            - PER_TIER
+            - WHOLE_BALANCE
+        applicabilityConditionList:
+          type: array
+          description: Conditions for the applicability of the tiered rate
+          items:
+            $ref: '#/components/schemas/BankingProductRateCondition'
+        additionalInfo:
+          type: string
+          example: additional info for tier
+          description: Display text providing more information on the rate tier.
+        additionalInfoUri:
+          type: string
+          example: https://tier.example.com.au
+          description: Link to a web page with more information on this rate tier
+          x-cds-type: URIString
+      description: Defines the criteria and conditions for which a rate applies
+    BankingProductRateCondition:
+      type: object
+      properties:
+        rateApplicabilityType:
+          type: string
+          description: The type of rate applicability condition described
+          enum:
+            - MIN_DEPOSITS
+            - MIN_DEPOSIT_AMOUNT
+            - DEPOSIT_BALANCE_INCREASED
+            - EXISTING_CUST
+            - NEW_ACCOUNTS
+            - NEW_CUSTOMER
+            - NEW_CUSTOMER_TO_GROUP
+            - ONLINE_ONLY
+            - OTHER
+            - MIN_PURCHASES
+            - MAX_WITHDRAWALS
+            - MAX_WITHDRAWAL_AMOUNT
+        additionalValue:
+          type: string
+          description: Generic field containing additional information relevant to the rate applicability condition
+        additionalInfo:
+          type: string
+          example: additional info for rate condition
+          description: Display text providing more information on the condition
+        additionalInfoUri:
+          type: string
+          description: Link to a web page with more information on this condition
+          example: https://ratecondition.example.com.au
+          x-cds-type: URIString
+      description: Defines a condition for the applicability of a tiered rate
+    ResponseBankingAccountList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/ResponseBankingAccountList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    BankingAccount:
+      type: object
+      required:
+        - accountId
+        - displayName
+        - maskedNumber
+        - productCategory
+        - productName
+      properties:
+        accountId:
+          type: string
+          example: d9e75179-104f-47cf-9d29-18284222bab0
+          description: A unique ID of the account adhering to the standards for ID permanence
+          x-cds-type: ASCIIString
+        creationDate:
+          type: string
+          example: "2012-12-25"
+          description: Date that the account was created (if known)
+          x-cds-type: DateString
+        displayName:
+          type: string
+          example: savings
+          description: The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
+        nickname:
+          type: string
+          example: sav
+          description: A customer supplied nick name for the account
+        openStatus:
+          type: string
+          example: OPEN
+          description: Open or closed status for the account. If not present then OPEN is assumed
+          default: OPEN
+          enum:
+            - OPEN
+            - CLOSED
+        isOwned:
+          type: boolean
+          example: true
+          description: Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
+          default: true
+          x-cds-type: Boolean
+        accountOwnership:
+          type: string
+          description: Value indicating the number of customers that have ownership of the account, according to the data holder's definition of account ownership. Does not indicate that all account owners are eligible consumers
+          enum:
+            - UNKNOWN
+            - ONE_PARTY
+            - TWO_PARTY
+            - MANY_PARTY
+            - OTHER
+        maskedNumber:
+          type: string
+          example: "xxx-xxx xxxxx1234"
+          description: A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
+          x-cds-type: MaskedAccountString
+        productCategory:
+          $ref: '#/components/schemas/BankingProductCategory'
+        productName:
+          type: string
+          example: Savings
+          description: The unique identifier of the account as defined by the data holder (akin to model number for the account)
+    ResponseBankingAccountById:
+      type: object
+      required:
+        - data
+        - links
+      properties:
+        data:
+          $ref: '#/components/schemas/BankingAccountDetail'
+        links:
+          $ref: '#/components/schemas/Links'
+        meta:
+          $ref: '#/components/schemas/Meta'
+    BankingAccountDetail:
+      allOf:
+        - $ref: '#/components/schemas/BankingAccount'
+        - type: object
+          properties:
+            bsb:
+              type: string
+              example: 062000
+              description: The unmasked BSB for the account. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
+            accountNumber:
+              example: 12345678
+              type: string
+              description: The unmasked account number for the account. Should not be supplied if the account number is a PAN requiring PCI compliance. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
+            bundleName:
+              type: string
+              example: ""
+              description: Optional field to indicate if this account is part of a bundle that is providing additional benefit for to the customer
+            specificAccountUType:
+              type: string
+              example: termDeposit
+              description: The type of structure to present account specific fields.
+              enum:
+                - termDeposit
+                - creditCard
+                - loan
+            termDeposit:
+              type: array
+              items:
+                $ref: '#/components/schemas/BankingTermDepositAccount'
+            creditCard:
+              $ref: '#/components/schemas/BankingCreditCardAccount'
+            loan:
+              $ref: '#/components/schemas/BankingLoanAccount'
+            depositRate:
+              type: string
+              example: 2.20
+              description: current rate to calculate interest earned being applied to deposit balances as it stands at the time of the API call
+              x-cds-type: RateString
+            lendingRate:
+              type: string
+              example: 3.19
+              description: The current rate to calculate interest payable being applied to lending balances as it stands at the time of the API call
+              x-cds-type: RateString
+            depositRates:
+              type: array
+              description: Fully described deposit rates for this account based on the equivalent structure in Product Reference
+              items:
+                $ref: '#/components/schemas/BankingProductDepositRate'
+            lendingRates:
+              type: array
+              description: Fully described deposit rates for this account based on the equivalent structure in Product Reference
+              items:
+                $ref: '#/components/schemas/BankingProductLendingRateV2'
+            features:
+              type: array
+              description: Array of features of the account based on the equivalent structure in Product Reference with the following additional field
+              items:
+                $ref: '#/components/schemas/BankingAccountProductFeature'
+            fees:
+              type: array
+              description: Fees and charges applicable to the account based on the equivalent structure in Product Reference
+              items:
+                $ref: '#/components/schemas/BankingProductFee'
+            addresses:
+              type: array
+              description: The addresses for the account to be used for correspondence
+              items:
+                $ref: '#/components/schemas/CommonPhysicalAddress'
+            isInstalmentDetailAvailable:
+              type: boolean
+              description: True if any active or inactive instalment plans are available in the instalment plan endpoints. False if instalment plans are not applicable to the account
+            instalments:
+              $ref: '#/components/schemas/BankingProductInstalments'
+          x-conditional:
+            - termDeposit
+            - creditCard
+            - loan
+    BankingAccountProductFeature:
+      type: object
+      description: Array of features of the account based on the equivalent structure in Product Reference with the following additional field
+      allOf:
+        - $ref: '#/components/schemas/BankingProductFeature'
+        - type: object
+          properties:
+            isActivated:
+              type: boolean
+              description: True if the feature is already activated and false if the feature is available for activation. (note this is an additional field appended to the feature object defined in the Product Reference payload)
+              example: true
+              x-cds-type: Boolean
+    BankingTermDepositAccount:
+      type: object
+      required:
+        - lodgementDate
+        - maturityDate
+        - maturityInstructions
+      properties:
+        lodgementDate:
+          type: string
+          example: "2017-12-31"
+          description: The lodgement date of the original deposit
+          x-cds-type: DateString
+        maturityDate:
+          type: string
+          example: "2018-12-30"
+          description: Maturity date for the term deposit
+          x-cds-type: DateString
+        maturityAmount:
+          type: string
+          example: "10000.00"
+          description: Amount to be paid upon maturity. If absent it implies the amount to paid is variable and cannot currently be calculated
+          x-cds-type: AmountString
+        maturityCurrency:
+          type: string
+          example: AUD
+          description: If absent assumes AUD
+          x-cds-type: CurrencyString
+        maturityInstructions:
+          type: string
+          example: ROLLED_OVER
+          description: Current instructions on action to be taken at maturity. This includes default actions that may be specified in the terms and conditions for the product e.g. roll-over to the same term and frequency of interest payments
+          enum:
+            - ROLLED_OVER
+            - PAID_OUT_AT_MATURITY
+            - HOLD_ON_MATURITY
+    BankingCreditCardAccount:
+      type: object
+      required:
+        - minPaymentAmount
+        - paymentDueAmount
+        - paymentDueDate
+      properties:
+        minPaymentAmount:
+          type: string
+          example: 99.99
+          description: The minimum payment amount due for the next card payment
+          x-cds-type: AmountString
+        paymentDueAmount:
+          type: string
+          example: 2999.99
+          description: The amount due for the next card payment
+          x-cds-type: AmountString
+        paymentCurrency:
+          type: string
+          example: AUD
+          description: If absent assumes AUD
+          x-cds-type: CurrencyString
+        paymentDueDate:
+          type: string
+          example: "2021-01-01"
+          description: Date that the next payment for the card is due
+          x-cds-type: DateString
+    BankingLoanAccount:
+      type: object
+      required:
+        - loanEndDate
+        - nextInstalmentDate
+        - repaymentFrequency
+      properties:
+        originalStartDate:
+          type: string
+          example: "2017-12-31"
+          description: Optional original start date for the loan
+          x-cds-type: DateString
+        originalLoanAmount:
+          type: string
+          example: 300000.00
+          description: Optional original loan value
+          x-cds-type: AmountString
+        originalLoanCurrency:
+          type: string
+          example: AUD
+          description: If absent assumes AUD
+          x-cds-type: CurrencyString
+        loanEndDate:
+          type: string
+          example: "2047-12-30"
+          description: Date that the loan is due to be repaid in full
+          x-cds-type: DateString
+        nextInstalmentDate:
+          type: string
+          example: "2021-02-28"
+          description: Next date that an instalment is required
+          x-cds-type: DateString
+        minInstalmentAmount:
+          type: string
+          example: 999.99
+          description: Minimum amount of next instalment
+          x-cds-type: AmountString
+        minInstalmentCurrency:
+          type: string
+          example: AUD
+          description: If absent assumes AUD
+          x-cds-type: CurrencyString
+        maxRedraw:
+          type: string
+          example: 9999.99
+          description: Maximum amount of funds that can be redrawn. If not present redraw is not available even if the feature exists for the account
+          x-cds-type: AmountString
+        maxRedrawCurrency:
+          type: string
+          example: AUD
+          description: If absent assumes AUD
+          x-cds-type: CurrencyString
+        minRedraw:
+          type: string
+          example: 1000
+          description: Minimum redraw amount
+          x-cds-type: AmountString
+        minRedrawCurrency:
+          type: string
+          example: AUD
+          description: If absent assumes AUD
+          x-cds-type: CurrencyString
+        offsetAccountEnabled:
+          type: boolean
+          example: true
+          description: Set to true if one or more offset accounts are configured for this loan account
+          x-cds-type: Boolean
+        offsetAccountIds:
+          type: array
+          description: The accountIDs of the configured offset accounts attached to this loan. Only offset accounts that can be accessed under the current authorisation should be included. It is expected behaviour that offsetAccountEnabled is set to true but the offsetAccountIds field is absent or empty. This represents a situation where an offset account exists but details can not be accessed under the current authorisation
+          items:
+            example: ["f632041c-d7c8-4679-a165-aa406cd62b13"]
+            type: string
+            x-cds-type: ASCIIString
+        repaymentType:
+          type: string
+          description: Options in place for repayments. If absent defaults to PRINCIPAL_AND_INTEREST
+          example: INTEREST_ONLY
+          default: PRINCIPAL_AND_INTEREST
+          enum:
+            - INTEREST_ONLY
+            - OTHER
+            - PRINCIPAL_AND_INTEREST
+            - UNCONSTRAINED
+        repaymentFrequency:
+          type: string
+          example: P1M
+          description: The expected or required repayment frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+          x-cds-type: ExternalRef
+    BankingProductInstalments:
+      type: object
+      description: Details of instalment features on the account
+      required:
+        - minimumSplit
+        - maximumSplit
+      properties:
+        maximumConcurrentPlans:
+          type: integer
+          description: Maximum number of concurrent active instalment plans that may be created on the account. If absent there is no predetermined maximum number
+          x-cds-type: NaturalNumber
+        instalmentsLimit:
+          type: string
+          description: Maximum total value of transactions that may be converted to instalments
+          x-cds-type: AmountString
+        minimumPlanValue:
+          type: string
+          description: Minimum transaction value that can be converted into an instalment plan
+          x-cds-type: AmountString
+        maximumPlanValue:
+          type: string
+          description: Maximum transaction value that can be converted into an instalment plan
+          x-cds-type: AmountString
+        minimumSplit:
+          type: integer
+          description: Minimum number of instalments allowed
+          x-cds-type: PositiveInteger
+        maximumSplit:
+          type: integer
+          description: Maximum number of instalments allowed
+          x-cds-type: PositiveInteger
+    ResponseBankingTransactionList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/ResponseBankingTransactionList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    BankingTransaction:
+      type: object
+      required:
+        - accountId
+        - amount
+        - description
+        - isDetailAvailable
+        - reference
+        - status
+        - type
+      properties:
+        accountId:
+          type: string
+          example: f632041c-d7c8-4679-a165-aa406cd62b13
+          description: ID of the account for which transactions are provided
+          x-cds-type: ASCIIString
+        transactionId:
+          type: string
+          example: f111111-d7c8-4679-a165-aa406cd62b13
+          description: A unique ID of the transaction adhering to the standards for ID permanence.  This is mandatory (through hashing if necessary) unless there are specific and justifiable technical reasons why a transaction cannot be uniquely identified for a particular account type
+          x-cds-type: ASCIIString
+        isDetailAvailable:
+          type: boolean
+          example: true
+          description: True if extended information is available using the transaction detail end point. False if extended data is not available
+          x-cds-type: Boolean
+        type:
+          type: string
+          example: FEE
+          description: The type of the transaction
+          enum:
+            - DIRECT_DEBIT
+            - FEE
+            - INTEREST_CHARGED
+            - INTEREST_PAID
+            - PAYMENT
+            - TRANSFER_OUTGOING
+            - TRANSFER_INCOMING
+            - OTHER
+        status:
+          type: string
+          example: POSTED
+          description: Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction
+          enum:
+            - PENDING
+            - POSTED
+        description:
+          example: banking fee
+          type: string
+          description: The transaction description as applied by the financial institution
+        postingDateTime:
+          type: string
+          example: "2021-01-12T15:43:00.121Z"
+          description: The time the transaction was posted. This field is Mandatory if the transaction has status POSTED.  This is the time that appears on a standard statement.
+            DateTimeString can be found at https://consumerdatastandardsaustralia.github.io/standards/#common-field-types
+          x-cds-type: DateTimeString
+        valueDateTime:
+          type: string
+          example: "2021-01-12T15:43:00.121Z"
+          description: Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry
+          x-cds-type: DateTimeString
+        executionDateTime:
+          type: string
+          example: "2021-01-12T15:43:00.121Z"
+          description: The time the transaction was executed by the originating customer, if available
+          x-cds-type: DateTimeString
+        amount:
+          type: string
+          example: 100.00
+          description: The value of the transaction. Negative values mean money was outgoing from the account
+          x-cds-type: AmountString
+        currency:
+          type: string
+          example: AUD
+          description: The currency for the transaction amount. AUD assumed if not present
+          x-cds-type: CurrencyString
+        reference:
+          type: string
+          example: overdraw
+          description: The reference for the transaction provided by the originating institution. Empty string if no data provided
+        merchantName:
+          type: string
+          example: McDonald
+          description: Name of the merchant for an outgoing payment to a merchant
+        merchantCategoryCode:
+          type: string
+          example: RANDOM
+          description: The merchant category code (or MCC) for an outgoing payment to a merchant
+        billerCode:
+          type: string
+          example: 234213427384923
+          description: BPAY Biller Code for the transaction (if available)
+        billerName:
+          type: string
+          example: test biller
+          description: Name of the BPAY biller for the transaction (if available)
+        crn:
+          type: string
+          example: 1234asdf1
+          description: BPAY CRN for the transaction (if available)
+        apcaNumber:
+          type: string
+          example: 111111
+          description: 6 Digit APCA number for the initiating institution. The field is fixed-width and padded with leading zeros if applicable.
+      x-conditional:
+        - transactionId
+        - postingDateTime
+    ResponseBankingTransactionById:
+      type: object
+      required:
+        - data
+        - links
+      properties:
+        data:
+          $ref: '#/components/schemas/BankingTransactionDetail'
+        links:
+          $ref: '#/components/schemas/Links'
+        meta:
+          $ref: '#/components/schemas/Meta'
+    BankingTransactionDetail:
+      allOf:
+        - $ref: '#/components/schemas/BankingTransaction'
+        - type: object
+          required:
+            - extendedData
+          properties:
+            extendedData:
+              $ref: '#/components/schemas/BankingTransactionDetail_extendedData'
+    ResponseBankingAccountsBalanceList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/ResponseBankingAccountsBalanceList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    ResponseBankingAccountsBalanceById:
+      required:
+        - data
+        - links
+      properties:
+        data:
+          $ref: '#/components/schemas/BankingBalance'
+        links:
+          $ref: '#/components/schemas/Links'
+        meta:
+          $ref: '#/components/schemas/Meta'
+    BankingBalance:
+      type: object
+      required:
+        - accountId
+        - availableBalance
+        - currentBalance
+      properties:
+        accountId:
+          type: string
+          example: f632041c-d7c8-4679-a165-aa406cd62b13
+          description: A unique ID of the account adhering to the standards for ID permanence
+          x-cds-type: ASCIIString
+        currentBalance:
+          type: string
+          example: "10000.00"
+          description: The balance of the account at this time. Should align to the balance available via other channels such as Internet Banking. Assumed to be negative if the customer has money owing
+          x-cds-type: AmountString
+        availableBalance:
+          type: string
+          example: "10000.00"
+          description: Balance representing the amount of funds available for transfer. Assumed to be zero or positive
+          x-cds-type: AmountString
+        creditLimit:
+          type: string
+          example: "10000.00"
+          description: Object representing the maximum amount of credit that is available for this account. Assumed to be zero if absent
+          x-cds-type: AmountString
+        amortisedLimit:
+          type: string
+          example: "0.00"
+          description: Object representing the available limit amortised according to payment schedule. Assumed to be zero if absent
+          x-cds-type: AmountString
+        currency:
+          type: string
+          example: AUD
+          description: The currency for the balance amounts. If absent assumed to be AUD
+          x-cds-type: CurrencyString
+        purses:
+          type: array
+          description: Optional array of balances for the account in other currencies. Included to support accounts that support multi-currency purses such as Travel Cards
+          items:
+            $ref: '#/components/schemas/BankingBalancePurse'
+    BankingBalancePurse:
+      type: object
+      required:
+        - amount
+      properties:
+        amount:
+          type: string
+          example: "1000.00"
+          description: The balance available for this additional currency purse
+          x-cds-type: AmountString
+        currency:
+          type: string
+          example: AUD
+          description: The currency for the purse
+          x-cds-type: CurrencyString
+    ResponseBankingPayeeList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/ResponseBankingPayeeList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    ResponseBankingPayeeById:
+      type: object
+      required:
+        - data
+        - links
+      properties:
+        data:
+          $ref: '#/components/schemas/BankingPayeeDetail'
+        links:
+          $ref: '#/components/schemas/Links'
+        meta:
+          $ref: '#/components/schemas/Meta'
+    BankingPayee:
+      type: object
+      required:
+        - nickname
+        - payeeId
+        - type
+      properties:
+        payeeId:
+          type: string
+          example: f632041c-d7c8-4679-a165-aa406cd62b13
+          description: ID of the payee adhering to the rules of ID permanence
+          x-cds-type: ASCIIString
+        nickname:
+          type: string
+          example: friend A
+          description: The short display name of the payee as provided by the customer. Where a customer has not provided a nickname, a display name derived by the bank for the payee consistent with existing digital banking channels
+        description:
+          type: string
+          example: share riding
+          description: A description of the payee provided by the customer
+        type:
+          type: string
+          example: DOMESTIC
+          description: The type of payee. DOMESTIC means a registered payee for domestic payments including NPP. INTERNATIONAL means a registered payee for international payments. BILLER means a registered payee for BPAY
+          enum:
+            - BILLER
+            - DIGITAL_WALLET
+            - DOMESTIC
+            - INTERNATIONAL
+        creationDate:
+          type: string
+          example: "2017-12-31"
+          description: The date the payee was created by the customer
+          x-cds-type: DateString
+    BankingPayeeDetail:
+      allOf:
+        - $ref: '#/components/schemas/BankingPayee'
+        - type: object
+          required:
+            - payeeUType
+          properties:
+            payeeUType:
+              type: string
+              example: biller
+              description: Type of object included that describes the payee in detail
+              enum:
+                - biller
+                - digitalWallet
+                - domestic
+                - international
+            biller:
+              $ref: '#/components/schemas/BankingBillerPayee'
+            digitalWallet:
+              $ref: '#/components/schemas/BankingDigitalWalletPayee'
+            domestic:
+              $ref: '#/components/schemas/BankingDomesticPayee'
+            international:
+              $ref: '#/components/schemas/BankingInternationalPayee'
+          x-conditional:
+            - biller
+            - digitalWallet
+            - domestic
+            - international
+    BankingDigitalWalletPayee:
+      required:
+        - identifier
+        - name
+        - provider
+        - type
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
+        identifier:
+          type: string
+          description: The identifier of the digital wallet (dependent on type)
+        type:
+          type: string
+          description: The type of the digital wallet identifier
+          enum:
+            - EMAIL
+            - CONTACT_NAME
+            - TELEPHONE
+        provider:
+          type: string
+          description: The provider of the digital wallet
+          enum:
+            - PAYPAL_AU
+            - OTHER
+    BankingDomesticPayee:
+      type: object
+      required:
+        - payeeAccountUType
+      properties:
+        payeeAccountUType:
+          type: string
+          description: 'Type of account object included. Valid values are: **account** A standard Australian account defined by BSB/Account Number. **card** A credit or charge card to pay to (note that PANs are masked). **payId** A PayID recognised by NPP'
+          example: card
+          enum:
+            - account
+            - card
+            - payId
+        account:
+          $ref: '#/components/schemas/BankingDomesticPayeeAccount'
+        card:
+          $ref: '#/components/schemas/BankingDomesticPayeeCard'
+        payId:
+          $ref: '#/components/schemas/BankingDomesticPayeePayId'
+      x-conditional:
+        - account
+        - card
+        - payId
+    BankingDomesticPayeeAccount:
+      type: object
+      required:
+        - accountNumber
+        - bsb
+      properties:
+        accountName:
+          type: string
+          example: friendA
+          description: Name of the account to pay to
+        bsb:
+          type: string
+          example: 060000
+          description: BSB of the account to pay to
+        accountNumber:
+          example: 12345678
+          type: string
+          description: Number of the account to pay to
+    BankingDomesticPayeeCard:
+      type: object
+      required:
+        - cardNumber
+      properties:
+        cardNumber:
+          type: string
+          example: xxxx xxxx xxxx 1234
+          description: Name of the account to pay to
+          x-cds-type: MaskedPANString
+    BankingDomesticPayeePayId:
+      type: object
+      required:
+        - identifier
+        - type
+      properties:
+        name:
+          type: string
+          example: friend B
+          description: The name assigned to the PayID by the owner of the PayID
+        identifier:
+          type: string
+          example: 0400000000
+          description: The identifier of the PayID (dependent on type)
+        type:
+          type: string
+          example: TELEPHONE
+          description: The type of the PayID
+          enum:
+            - ABN
+            - EMAIL
+            - ORG_IDENTIFIER
+            - TELEPHONE
+    BankingBillerPayee:
+      type: object
+      required:
+        - billerCode
+        - billerName
+      properties:
+        billerCode:
+          type: string
+          example: 1231412141
+          description: BPAY Biller Code of the Biller
+        crn:
+          type: string
+          example: MaskedPANString
+          description: BPAY CRN of the Biller. If the contents of the CRN match the format of a Credit Card PAN then it should be masked using the rules applicable for the MaskedPANString common type
+        billerName:
+          type: string
+          example: BillerA
+          description: Name of the Biller
+      x-conditional:
+        - crn
+    BankingInternationalPayee:
+      type: object
+      required:
+        - bankDetails
+        - beneficiaryDetails
+      properties:
+        beneficiaryDetails:
+          $ref: '#/components/schemas/BankingInternationalPayee_beneficiaryDetails'
+        bankDetails:
+          $ref: '#/components/schemas/BankingInternationalPayee_bankDetails'
+    ResponseBankingDirectDebitAuthorisationList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/ResponseBankingDirectDebitAuthorisationList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    BankingDirectDebit:
+      type: object
+      required:
+        - accountId
+        - authorisedEntity
+      properties:
+        accountId:
+          type: string
+          example: f632041c-d7c8-4679-a165-aa406cd62b13
+          description: A unique ID of the account adhering to the standards for ID permanence.
+          x-cds-type: ASCIIString
+        authorisedEntity:
+          $ref: '#/components/schemas/BankingAuthorisedEntity'
+        lastDebitDateTime:
+          type: string
+          example: "1997-01-12T15:43:00.121Z"
+          description: The date and time of the last debit executed under this authorisation
+          x-cds-type: DateTimeString
+        lastDebitAmount:
+          type: string
+          example: 100.00
+          description: The amount of the last debit executed under this authorisation
+          x-cds-type: AmountString
+    BankingAuthorisedEntity:
+      type: object
+      properties:
+        description:
+          type: string
+          example: broadband fee
+          description: Description of the authorised entity derived from previously executed direct debits
+        financialInstitution:
+          type: string
+          example: CBA
+          description: Name of the financial institution through which the direct debit will be executed. Is required unless the payment is made via a credit card scheme
+        abn:
+          type: string
+          example: 12341256
+          description: Australian Business Number for the authorised entity
+        acn:
+          type: string
+          example: 234123512521
+          description: Australian Company Number for the authorised entity
+        arbn:
+          type: string
+          example: 241234213424
+          description: Australian Registered Body Number for the authorised entity
+    ResponseBankingScheduledPaymentsList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/ResponseBankingScheduledPaymentsList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    BankingScheduledPayment:
+      type: object
+      required:
+        - from
+        - payeeReference
+        - payerReference
+        - paymentSet
+        - recurrence
+        - scheduledPaymentId
+        - status
+      properties:
+        scheduledPaymentId:
+          type: string
+          description: A unique ID of the scheduled payment adhering to the standards for ID permanence
+          example: f632041c-d7c8-4679-a165-aa406cd62b13
+          x-cds-type: ASCIIString
+        nickname:
+          type: string
+          example: council
+          description: The short display name of the payee as provided by the customer
+        payerReference:
+          type: string
+          example: 1231234142
+          description: The reference for the transaction that will be used by the originating institution for the purposes of constructing a statement narrative on the payer's account. Empty string if no data provided
+        payeeReference:
+          type: string
+          example: 234134241234
+          description: The reference for the transaction that will be provided by the originating institution. Empty string if no data provided
+        status:
+          type: string
+          example: ACTIVE
+          description: Indicates whether the schedule is currently active. The value SKIP is equivalent to ACTIVE except that the customer has requested the next normal occurrence to be skipped.
+          enum:
+            - ACTIVE
+            - INACTIVE
+            - SKIP
+        from:
+          $ref: '#/components/schemas/BankingScheduledPaymentFrom'
+        paymentSet:
+          type: array
+          items:
+            $ref: '#/components/schemas/BankingScheduledPaymentSet'
+        recurrence:
+          $ref: '#/components/schemas/BankingScheduledPaymentRecurrence'
+    BankingScheduledPaymentSet:
+      required:
+        - to
+      properties:
+        to:
+          $ref: '#/components/schemas/BankingScheduledPaymentTo'
+        isAmountCalculated:
+          type: boolean
+          example: true
+          description: Flag indicating whether the amount of the payment is calculated based on the context of the event. For instance a payment to reduce the balance of a credit card to zero. If absent then false is assumed
+          x-cds-type: Boolean
+        amount:
+          type: string
+          example: 123.00
+          description: The amount of the next payment if known. Mandatory unless the isAmountCalculated field is set to true. Must be zero or positive if present
+          x-cds-type: AmountString
+        currency:
+          type: string
+          example: AUD
+          description: The currency for the payment. AUD assumed if not present
+          x-cds-type: CurrencyString
+      description: The set of payment amounts and destination accounts for this payment accommodating multi-part payments. A single entry indicates a simple payment with one destination account. Must have at least one entry
+      x-conditional:
+        - amount
+    BankingScheduledPaymentTo:
+      type: object
+      required:
+        - toUType
+      properties:
+        toUType:
+          type: string
+          description: The type of object provided that specifies the destination of the funds for the payment.
+          example: payeeId
+          enum:
+            - accountId
+            - payeeId
+            - domestic
+            - biller
+            - digitalWallet
+            - international
+        accountId:
+          type: string
+          example: ""
+          description: Present if toUType is set to accountId. Indicates that the payment is to another account that is accessible under the current consent
+          x-cds-type: ASCIIString
+        payeeId:
+          type: string
+          example: f632041c-d7c8-4679-a165-aa406cd62b13
+          description: Present if toUType is set to payeeId. Indicates that the payment is to registered payee that can be accessed using the payee end point. If the Bank Payees scope has not been consented to then a payeeId should not be provided and the full payee details should be provided instead
+          x-cds-type: ASCIIString
+        domestic:
+          $ref: '#/components/schemas/BankingDomesticPayee'
+        biller:
+          $ref: '#/components/schemas/BankingBillerPayee'
+        digitalWallet:
+          $ref: '#/components/schemas/BankingDigitalWalletPayee'
+        international:
+          $ref: '#/components/schemas/BankingInternationalPayee'
+      description: Object containing details of the destination of the payment. Used to specify a variety of payment destination types
+      x-conditional:
+        - accountId
+        - payeeId
+        - domestic
+        - biller
+        - digitalWallet
+        - international
+    BankingScheduledPaymentFrom:
+      type: object
+      required:
+        - accountId
+      properties:
+        accountId:
+          type: string
+          example: f632041c-d7c8-4679-a165-aa406cd62b13
+          description: ID of the account that is the source of funds for the payment
+          x-cds-type: ASCIIString
+      description: Object containing details of the source of the payment. Currently only specifies an account ID but provided as an object to facilitate future extensibility and consistency with the to object
+    BankingScheduledPaymentRecurrence:
+      type: object
+      required:
+        - recurrenceUType
+      properties:
+        nextPaymentDate:
+          type: string
+          example: "2017-12-31"
+          description: The date of the next payment under the recurrence schedule
+          x-cds-type: DateString
+        recurrenceUType:
+          type: string
+          description: The type of recurrence used to define the schedule
+          example: onceOff
+          enum:
+            - onceOff
+            - intervalSchedule
+            - lastWeekDay
+            - eventBased
+        onceOff:
+          $ref: '#/components/schemas/BankingScheduledPaymentRecurrenceOnceOff'
+        intervalSchedule:
+          $ref: '#/components/schemas/BankingScheduledPaymentRecurrenceIntervalSchedule'
+        lastWeekDay:
+          $ref: '#/components/schemas/BankingScheduledPaymentRecurrenceLastWeekday'
+        eventBased:
+          $ref: '#/components/schemas/BankingScheduledPaymentRecurrenceEventBased'
+      description: Object containing the detail of the schedule for the payment
+      x-conditional:
+        - onceOff
+        - intervalSchedule
+        - lastWeekDay
+        - eventBased
+    BankingScheduledPaymentRecurrenceOnceOff:
+      type: object
+      required:
+        - paymentDate
+      properties:
+        paymentDate:
+          type: string
+          example: "2017-12-31"
+          description: The scheduled date for the once off payment
+          x-cds-type: DateString
+      description: Indicates that the payment is a once off payment on a specific future date. Mandatory if recurrenceUType is set to onceOff
+    BankingScheduledPaymentRecurrenceIntervalSchedule:
+      type: object
+      required:
+        - intervals
+      properties:
+        finalPaymentDate:
+          type: string
+          example: "2017-12-31"
+          description: The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+          x-cds-type: DateString
+        paymentsRemaining:
+          type: integer
+          example: 12
+          description: Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value, If neither field is present the payments will continue indefinitely
+          x-cds-type: PositiveInteger
+        nonBusinessDayTreatment:
+          type: string
+          example: AFTER
+          description: Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+          default: 'ON'
+          enum:
+            - 'AFTER'
+            - 'BEFORE'
+            - 'ON'
+            - 'ONLY'
+        intervals:
+          type: array
+          description: An array of interval objects defining the payment schedule.  Each entry in the array is additive, in that it adds payments to the overall payment schedule.  If multiple intervals result in a payment on the same day then only one payment will be made. Must have at least one entry
+          items:
+            $ref: '#/components/schemas/BankingScheduledPaymentInterval'
+      description: Indicates that the schedule of payments is defined by a series of intervals. Mandatory if recurrenceUType is set to intervalSchedule
+    BankingScheduledPaymentInterval:
+      type: object
+      required:
+        - interval
+      properties:
+        interval:
+          type: string
+          example: P1D
+          description: An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+          x-cds-type: ExternalRef
+        dayInInterval:
+          type: string
+          example: ""
+          description: Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
+          x-cds-type: ExternalRef
+    BankingScheduledPaymentRecurrenceLastWeekday:
+      type: object
+      required:
+        - interval
+        - lastWeekDay
+      properties:
+        finalPaymentDate:
+          type: string
+          example: "2017-12-31"
+          description: The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+          x-cds-type: DateString
+        paymentsRemaining:
+          type: integer
+          description: Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+          example: 12
+          x-cds-type: PositiveInteger
+        interval:
+          type: string
+          description: The interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+          example: P1D
+          x-cds-type: ExternalRef
+        lastWeekDay:
+          type: string
+          example: MON
+          description: The weekDay specified. The payment will occur on the last occurrence of this weekday in the interval.
+          enum:
+            - MON
+            - TUE
+            - WED
+            - THU
+            - FRI
+            - SAT
+            - SUN
+        nonBusinessDayTreatment:
+          type: string
+          description: Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+          example: AFTER
+          default: 'ON'
+          enum:
+            - 'AFTER'
+            - 'BEFORE'
+            - 'ON'
+            - 'ONLY'
+      description: Indicates that the schedule of payments is defined according to the last occurrence of a specific weekday in an interval. Mandatory if recurrenceUType is set to lastWeekDay
+    BankingScheduledPaymentRecurrenceEventBased:
+      type: object
+      required:
+        - description
+      properties:
+        description:
+          type: string
+          example: pay every Thursday
+          description: Description of the event and conditions that will result in the payment. Expected to be formatted for display to a customer
+      description: Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if recurrenceUType is set to eventBased
+    ResponseCommonCustomer:
+      type: object
+      required:
+        - data
+        - links
+      properties:
+        data:
+          $ref: '#/components/schemas/ResponseCommonCustomer_data'
+        links:
+          $ref: '#/components/schemas/Links'
+        meta:
+          $ref: '#/components/schemas/Meta'
+      x-conditional:
+        - person
+        - organisation
+    ResponseCommonCustomerDetail:
+      type: object
+      required:
+        - data
+        - links
+      properties:
+        data:
+          $ref: '#/components/schemas/ResponseCommonCustomerDetail_data'
+        links:
+          $ref: '#/components/schemas/Links'
+        meta:
+          $ref: '#/components/schemas/Meta'
+      x-conditional:
+        - person
+        - organisation
+    CommonPerson:
+      type: object
+      required:
+        - lastName
+        - middleNames
+      properties:
+        lastUpdateTime:
+          type: string
+          example: "1997-01-12T15:43:00.121Z"
+          description: The date and time that this record was last updated by the customer.  If no update has occurred then this date should reflect the initial creation date for the data
+          x-cds-type: DateTimeString
+        firstName:
+          type: string
+          example: John
+          description: For people with single names this field need not be present.  The single name should be in the lastName field
+        lastName:
+          type: string
+          example: Doe
+          description: For people with single names the single name should be in this field
+        middleNames:
+          type: array
+          description: Field is mandatory but array may be empty
+          example: []
+          items:
+            type: string
+        prefix:
+          type: string
+          example: Mr
+          description: Also known as title or salutation.  The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
+        suffix:
+          type: string
+          example: Jr
+          description: Used for a trailing suffix to the name (e.g. Jr)
+        occupationCode:
+          type: string
+          example: 233211
+          description: Value is a valid [ANZSCO](http://www.abs.gov.au/ANZSCO) Standard Occupation classification code. If the occupation code held by the data holder is not one of the supported [ANZSCO](http://www.abs.gov.au/ANZSCO) versions, then it must not be supplied.
+          x-cds-type: ExternalRef
+        occupationCodeVersion:
+          type: string
+          description: The applicable **[[ANZSCO]](#iref-ANZSCO)** release version of the occupation code provided. Mandatory if an ``occupationCode`` is supplied. If ``occupationCode`` is supplied but ``occupationCodeVersion`` is absent, default is ``ANZSCO_1220.0_2013_V1.2``
+          default: ANZSCO_1220.0_2013_V1.2
+          enum:
+            - ANZSCO_1220.0_2006_V1.0
+            - ANZSCO_1220.0_2006_V1.1
+            - ANZSCO_1220.0_2013_V1.2
+            - ANZSCO_1220.0_2013_V1.3
+    CommonPersonDetail:
+      allOf:
+        - $ref: '#/components/schemas/CommonPerson'
+        - type: object
+          required:
+            - emailAddresses
+            - phoneNumbers
+            - physicalAddresses
+          properties:
+            phoneNumbers:
+              type: array
+              description: Array is mandatory but may be empty if no phone numbers are held
+              items:
+                $ref: '#/components/schemas/CommonPhoneNumber'
+            emailAddresses:
+              type: array
+              description: May be empty
+              items:
+                $ref: '#/components/schemas/CommonEmailAddress'
+            physicalAddresses:
+              type: array
+              description: Must contain at least one address. One and only one address may have the purpose of REGISTERED. Zero or one, and no more than one, record may have the purpose of MAIL. If zero then the REGISTERED address is to be used for mail
+              items:
+                $ref: '#/components/schemas/CommonPhysicalAddressWithPurpose'
+    CommonOrganisation:
+      type: object
+      required:
+        - agentLastName
+        - agentRole
+        - businessName
+        - organisationType
+      properties:
+        lastUpdateTime:
+          type: string
+          example: "1997-01-12T15:43:00.121Z"
+          description: The date and time that this record was last updated by the customer. If no update has occurred then this date should reflect the initial creation date for the data
+          x-cds-type: DateTimeString
+        agentFirstName:
+          type: string
+          example: Jane
+          description: The first name of the individual providing access on behalf of the organisation. For people with single names this field need not be present.  The single name should be in the lastName field
+        agentLastName:
+          type: string
+          example: Doe
+          description: The last name of the individual providing access on behalf of the organisation. For people with single names the single name should be in this field
+        agentRole:
+          type: string
+          example: manager
+          description: The role of the individual identified as the agent who is providing authorisation.  Expected to be used for display. Default to Unspecified if the role is not known
+        businessName:
+          type: string
+          example: bumpty
+          description: Name of the organisation
+        legalName:
+          type: string
+          example: dumpty
+          description: Legal name, if different to the business name
+        shortName:
+          type: string
+          example: bdumpty
+          description: Short name used for communication, if different to the business name
+        abn:
+          type: string
+          example: 2342342342
+          description: Australian Business Number for the organisation
+        acn:
+          type: string
+          example: 13241234234
+          description: Australian Company Number for the organisation. Required only if an ACN is applicable for the organisation type
+        isACNCRegistered:
+          type: boolean
+          example: true
+          description: True if registered with the ACNC.  False if not. Absent or null if not confirmed.
+          x-cds-type: Boolean
+        industryCode:
+          type: string
+          example: MINING
+          description: A valid [ANZSIC](http://www.abs.gov.au/ANZSIC) code for the organisation. If the industry code held by the data holder is not one of the supported [ANZSIC](http://www.abs.gov.au/ANZSIC) versions, then it must not be supplied.
+          x-cds-type: ExternalRef
+        industryCodeVersion:
+          type: string
+          description: The applicable [ANZSIC](http://www.abs.gov.au/ANZSIC) release version of the industry code provided. Should only be supplied if ``industryCode`` is also supplied. If ``industryCode`` is supplied but ``industryCodeVersion`` is absent, default is ``ANZSIC_1292.0_2006_V2.0``
+          default: ANZSIC_1292.0_2006_V2.0
+          enum:
+            - ANZSIC_1292.0_2006_V1.0
+            - ANZSIC_1292.0_2006_V2.0
+        organisationType:
+          type: string
+          example: COMPANY
+          description: Legal organisation type
+          enum:
+            - COMPANY
+            - GOVERNMENT_ENTITY
+            - PARTNERSHIP
+            - SOLE_TRADER
+            - TRUST
+            - OTHER
+        registeredCountry:
+          type: string
+          description: Enumeration with values from [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country codes.  Assumed to be AUS if absent
+          example: AUS
+          x-cds-type: ExternalRef
+        establishmentDate:
+          type: string
+          description: The date the organisation described was established
+          example: "2017-12-31"
+          x-cds-type: DateString
+    CommonOrganisationDetail:
+      allOf:
+        - $ref: '#/components/schemas/CommonOrganisation'
+        - type: object
+          required:
+            - physicalAddresses
+          properties:
+            physicalAddresses:
+              type: array
+              description: Must contain at least one address. One and only one address may have the purpose of REGISTERED. Zero or one, and no more than one, record may have the purpose of MAIL. If zero then the REGISTERED address is to be used for mail
+              items:
+                $ref: '#/components/schemas/CommonPhysicalAddressWithPurpose'
+    CommonPhoneNumber:
+      type: object
+      required:
+        - fullNumber
+        - number
+        - purpose
+      properties:
+        isPreferred:
+          type: boolean
+          description: May be true for one and only one entry to indicate the preferred phone number. Assumed to be 'false' if not present
+          example: true
+          x-cds-type: Boolean
+        purpose:
+          type: string
+          description: The purpose of the number as specified by the customer
+          example: HOME
+          enum:
+            - MOBILE
+            - HOME
+            - INTERNATIONAL
+            - WORK
+            - OTHER
+            - UNSPECIFIED
+        countryCode:
+          type: string
+          description: If absent, assumed to be Australia (+61). The + should be included
+          example: +61
+        areaCode:
+          type: string
+          description: Required for non Mobile Phones, if field is present and refers to Australian code - the leading 0 should be omitted.
+          example: ""
+        number:
+          type: string
+          description: The actual phone number, with leading zeros as appropriate
+          example: 400000000
+        extension:
+          type: string
+          example: ""
+          description: An extension number (if applicable)
+        fullNumber:
+          type: string
+          description: Fully formatted phone number with country code, area code, number and extension incorporated. Formatted according to section 5.1.4. of [RFC 3966](https://www.ietf.org/rfc/rfc3966.txt)
+          example: +61400000000
+          x-cds-type: ExternalRef
+      x-conditional:
+        - areaCode
+    CommonEmailAddress:
+      type: object
+      required:
+        - address
+        - purpose
+      properties:
+        isPreferred:
+          type: boolean
+          description: May be true for one and only one email record in the collection. Denotes the default email address
+          example: true
+          x-cds-type: Boolean
+        purpose:
+          type: string
+          description: The purpose for the email, as specified by the customer (Enumeration)
+          example: WORK
+          enum:
+            - WORK
+            - HOME
+            - OTHER
+            - UNSPECIFIED
+        address:
+          type: string
+          example: 1 Pitt ST SYDNEY NSW 2000
+          description: A correctly formatted email address, as defined by the addr_spec format in [RFC 5322](https://www.ietf.org/rfc/rfc5322.txt)
+          x-cds-type: ExternalRef
+    CommonPhysicalAddressWithPurpose:
+      allOf:
+        - $ref: '#/components/schemas/CommonPhysicalAddress'
+        - type: object
+          required:
+            - purpose
+          properties:
+            purpose:
+              type: string
+              description: Enumeration of values indicating the purpose of the physical address
+              example: WORK
+              enum:
+                - MAIL
+                - PHYSICAL
+                - REGISTERED
+                - WORK
+                - OTHER
+    CommonPhysicalAddress:
+      type: object
+      required:
+        - addressUType
+      properties:
+        addressUType:
+          type: string
+          description: The type of address object present
+          example: simple
+          enum:
+            - simple
+            - paf
+        simple:
+          $ref: '#/components/schemas/CommonSimpleAddress'
+        paf:
+          $ref: '#/components/schemas/CommonPAFAddress'
+      x-conditional:
+        - simple
+        - paf
+    CommonSimpleAddress:
+      type: object
+      required:
+        - addressLine1
+        - city
+        - state
+      properties:
+        mailingName:
+          type: string
+          description: Name of the individual or business formatted for inclusion in an address used for physical mail
+          example: John Doe
+        addressLine1:
+          type: string
+          description: First line of the standard address object
+          example: 1 Pitt ST
+        addressLine2:
+          type: string
+          description: Second line of the standard address object
+          example: ""
+        addressLine3:
+          type: string
+          description: Third line of the standard address object
+          example: ""
+        postcode:
+          type: string
+          description: Mandatory for Australian addresses
+          example: 2000
+        city:
+          type: string
+          description: Name of the city or locality
+          example: SYDNEY
+        state:
+          type: string
+          description: Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+          example: NSW
+        country:
+          type: string
+          description: A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+          example: AUS
+          default: AUS
+          x-cds-type: ExternalRef
+      x-conditional:
+        - postcode
+    CommonPAFAddress:
+      type: object
+      required:
+        - localityName
+        - postcode
+        - state
+      properties:
+        dpid:
+          type: string
+          description: Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+          example: 17160
+        thoroughfareNumber1:
+          type: integer
+          description: Thoroughfare number for a property (first number in a property ranged address)
+          example: 16
+          x-cds-type: PositiveInteger
+        thoroughfareNumber1Suffix:
+          type: string
+          description: Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+          example: ""
+        thoroughfareNumber2:
+          type: integer
+          description: Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+          example: 19
+          x-cds-type: PositiveInteger
+        thoroughfareNumber2Suffix:
+          type: string
+          description: Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+          example: ""
+        flatUnitType:
+          type: string
+          description: Type of flat or unit for the address
+          example: unit
+        flatUnitNumber:
+          type: string
+          description: Unit number (including suffix, if applicable)
+          example: 10
+        floorLevelType:
+          type: string
+          description: Type of floor or level for the address
+          example: level
+        floorLevelNumber:
+          type: string
+          description: Floor or level number (including alpha characters)
+          example: 3
+        lotNumber:
+          type: string
+          description: Allotment number for the address
+          example: 10
+        buildingName1:
+          type: string
+          description: Building/Property name 1
+          example: summer
+        buildingName2:
+          type: string
+          description: Building/Property name 2
+          example: ""
+        streetName:
+          type: string
+          description: The name of the street
+          example: Long
+        streetType:
+          type: string
+          description: The street type. Valid enumeration defined by Australia Post PAF code file
+          example: ST
+        streetSuffix:
+          type: string
+          description: The street type suffix. Valid enumeration defined by Australia Post PAF code file
+        postalDeliveryType:
+          type: string
+          description: Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+          example: PO BOX
+        postalDeliveryNumber:
+          type: integer
+          description: Postal delivery number if the address is a postal delivery type
+          example: 15
+          x-cds-type: PositiveInteger
+        postalDeliveryNumberPrefix:
+          type: string
+          description: Postal delivery number prefix related to the postal delivery number
+          example: ""
+        postalDeliveryNumberSuffix:
+          type: string
+          description: Postal delivery number suffix related to the postal delivery number
+          example: ""
+        localityName:
+          type: string
+          description: Full name of locality
+          example: "Sydney"
+        postcode:
+          type: string
+          description: Postcode for the locality
+          example: 2000
+        state:
+          type: string
+          description: State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+          example: NSW
+      description: Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+    Links:
+      type: object
+      required:
+        - self
+      properties:
+        self:
+          type: string
+          description: Fully qualified link that generated the current response document
+          example: https://self.example.com.au
+          x-cds-type: URIString
+    Meta:
+      type: object
+      required:
+        - cdr_arrangement_id
+      properties:
+        cdr_arrangement_id:
+          type: string
+          description: Used to identify the consent arrangement for returned customer data
+          example: 998621c8-1e1d-44ca-826e-754b910e5697
+        fapiInteractionId:
+          type: string
+          description: Used to identify and verify the data-holder request
+          example: 2144eaaa-0b5b-4a97-a131-f42f2084ee45
+        debug:
+          type: object
+          description: troubleshooting for CTS testing
+          example: {}
+    LinksPaginated:
+      type: object
+      required:
+        - self
+      properties:
+        self:
+          type: string
+          description: Fully qualified link that generated the current response document.
+            https://self.example.com.au will be converted to https://self.example.com.au?page=1&page-size=25
+          example: https://self.example.com.au?page=3&page-size=25
+          x-cds-type: URIString
+        first:
+          type: string
+          description: URI to the first page of this set. Mandatory if this response is not the first page
+          example: https://self.example.com.au?page=1&page-size=25
+          x-cds-type: URIString
+        prev:
+          type: string
+          description: URI to the previous page of this set. Mandatory if this response is not the first page
+          example: https://self.example.com.au?page=2&page-size=25
+          x-cds-type: URIString
+        next:
+          type: string
+          description: URI to the next page of this set. Mandatory if this response is not the last page
+          example: https://self.example.com.au?page=4&page-size=25
+          x-cds-type: URIString
+        last:
+          type: string
+          description: URI to the last page of this set. Mandatory if this response is not the last page
+          example: https://self.example.com.au?page=15&page-size=25
+          x-cds-type: URIString
+      x-conditional:
+        - prev
+        - next
+        - first
+        - last
+    MetaPaginated:
+      type: object
+      required:
+        - totalPages
+        - totalRecords
+        - cdr_arrangement_id
+      properties:
+        totalRecords:
+          type: integer
+          description: The total number of records in the full set. See [pagination](#pagination).
+          example: 581
+          x-cds-type: NaturalNumber
+        totalPages:
+          type: integer
+          description: The total number of pages in the full set. See [pagination](#pagination).
+          example: 24
+          x-cds-type: NaturalNumber
+        isQueryParamUnsupported:
+          type: boolean
+          description: indicates whether text parameter is supported or not
+          example: true
+        cdr_arrangement_id:
+          type: string
+          description: Used to identify the consent arrangement for returned customer data
+          example: 998621c8-1e1d-44ca-826e-754b910e5697
+        fapiInteractionId:
+          type: string
+          description: Used to identify and verify the data-holder request
+          example: 2144eaaa-0b5b-4a97-a131-f42f2084ee45
+        debug:
+          type: object
+          description: troubleshooting info
+          example: {}
+    ResponseErrorList:
+      type: object
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResponseErrorList_errors'
+    BankingProductCategory:
+      type: string
+      description: The category to which a product or account belongs. See [here](#product-categories) for more details
+      example: LEASES
+      enum:
+        - BUSINESS_LOANS
+        - BUY_NOW_PAY_LATER
+        - CRED_AND_CHRG_CARDS
+        - LEASES
+        - MARGIN_LOANS
+        - OVERDRAFTS
+        - PERS_LOANS
+        - REGULATED_TRUST_ACCOUNTS
+        - RESIDENTIAL_MORTGAGES
+        - TERM_DEPOSITS
+        - TRADE_FINANCE
+        - TRAVEL_CARDS
+        - TRANS_AND_SAVINGS_ACCOUNTS
+    ResponseBankingAccountList_data:
+      required:
+        - accounts
+      properties:
+        accounts:
+          type: array
+          description: The list of accounts returned. If the filter results in an empty set then this array may have no records
+          items:
+            $ref: '#/components/schemas/BankingAccount'
+    ResponseBankingTransactionList_data:
+      required:
+        - transactions
+      properties:
+        transactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/BankingTransaction'
+    BankingTransactionDetail_extendedData_x2p101Payload:
+      required:
+        - extendedDescription
+      properties:
+        extendedDescription:
+          type: string
+          description: An extended string description. Only present if specified by the extensionUType field
+          example: extended descirption of a transaction
+        endToEndId:
+          type: string
+          description: An end to end ID for the payment created at initiation
+          example: end-to-endid-for-payment
+        purposeCode:
+          type: string
+          description: Purpose of the payment.  Format is defined by NPP standards for the x2p1.01 overlay service
+          example: payment-purpose-npp
+    BankingTransactionDetail_extendedData:
+      required:
+        - service
+      properties:
+        payer:
+          type: string
+          description: Label of the originating payer. Mandatory for inbound payment
+          example: Jane Doe
+        payee:
+          type: string
+          description: Label of the target PayID.  Mandatory for an outbound payment. The name assigned to the BSB/Account Number or PayID (by the owner of the PayID)
+          example: John Doe
+        extensionUType:
+          type: string
+          description: Optional extended data provided specific to transaction originated via NPP
+          example: x2p101Payload
+          enum:
+            - x2p101Payload
+        x2p101Payload:
+          $ref: '#/components/schemas/BankingTransactionDetail_extendedData_x2p101Payload'
+        service:
+          type: string
+          description: 'Identifier of the applicable overlay service. Valid values are: X2P1.01'
+          example: X2P1.01
+          enum:
+            - X2P1.01
+    ResponseBankingAccountsBalanceList_data:
+      required:
+        - balances
+      properties:
+        balances:
+          type: array
+          description: The list of balances returned
+          items:
+            $ref: '#/components/schemas/BankingBalance'
+    ResponseBankingPayeeList_data:
+      required:
+        - payees
+      properties:
+        payees:
+          type: array
+          description: The list of payees returned
+          items:
+            $ref: '#/components/schemas/BankingPayee'
+    BankingInternationalPayee_beneficiaryDetails:
+      required:
+        - country
+      properties:
+        name:
+          type: string
+          description: Name of the beneficiary
+          example: John Doe
+        country:
+          type: string
+          description: Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+          example: AUS
+          x-cds-type: ExternalRef
+        message:
+          type: string
+          description: Response message for the payment
+          example: Stay safe 2020
+    BankingInternationalPayee_bankDetails_bankAddress:
+      required:
+        - address
+        - name
+      properties:
+        name:
+          type: string
+          description: Name of the recipient Bank
+          example: Jane Doe
+        address:
+          type: string
+          description: Address of the recipient Bank
+          example: 1 Pitt ST Sydney NSW 2000
+    BankingInternationalPayee_bankDetails:
+      required:
+        - accountNumber
+        - country
+      properties:
+        country:
+          type: string
+          description: Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+          example: AUS
+          x-cds-type: ExternalRef
+        accountNumber:
+          type: string
+          description: Account Targeted for payment
+          example: 12345678
+        bankAddress:
+          $ref: '#/components/schemas/BankingInternationalPayee_bankDetails_bankAddress'
+        beneficiaryBankBIC:
+          type: string
+          description: Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
+          example: CTBAAU2S
+          x-cds-type: ExternalRef
+        fedWireNumber:
+          type: string
+          description: Number for Fedwire payment (Federal Reserve Wire Network)
+          example: "fed-wire-number"
+        sortCode:
+          type: string
+          description: Sort code used for account identification in some jurisdictions
+          example: "sort-code"
+        chipNumber:
+          type: string
+          description: Number for the Clearing House Interbank Payments System
+          example: "clearing-house-interbank-number"
+        routingNumber:
+          type: string
+          description: International bank routing number
+          example: "international-bank-routing-number"
+        legalEntityIdentifier:
+          type: string
+          description: The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
+          example: "legal-entity-id"
+          x-cds-type: ExternalRef
+    ResponseBankingDirectDebitAuthorisationList_data:
+      required:
+        - directDebitAuthorisations
+      properties:
+        directDebitAuthorisations:
+          type: array
+          description: The list of authorisations returned
+          items:
+            $ref: '#/components/schemas/BankingDirectDebit'
+    ResponseBankingScheduledPaymentsList_data:
+      required:
+        - scheduledPayments
+      properties:
+        scheduledPayments:
+          type: array
+          description: The list of scheduled payments to return
+          items:
+            $ref: '#/components/schemas/BankingScheduledPayment'
+    ResponseCommonCustomer_data:
+      required:
+        - customerUType
+      properties:
+        customerUType:
+          type: string
+          description: The type of customer object that is present
+          example: person
+          enum:
+            - person
+            - organisation
+        person:
+          $ref: '#/components/schemas/CommonPerson'
+        organisation:
+          $ref: '#/components/schemas/CommonOrganisation'
+    ResponseCommonCustomerDetail_data:
+      required:
+        - customerUType
+      properties:
+        customerUType:
+          type: string
+          description: The type of customer object that is present
+          example: person
+          enum:
+            - person
+            - organisation
+        person:
+          $ref: '#/components/schemas/CommonPersonDetail'
+        organisation:
+          $ref: '#/components/schemas/CommonOrganisationDetail'
+    ResponseErrorList_errors:
+      required:
+        - code
+        - detail
+        - title
+      properties:
+        code:
+          type: string
+          description: 'Error code'
+          example: "0001"
+        title:
+          type: string
+          description: 'Title of invalid parameter or payload property '
+          example: "Invalid account id"
+        detail:
+          type: string
+          description: ID of the account not found
+          example: "invalid format for account id"
+        meta:
+          type: object
+          description: Optional additional data for specific error types
+          properties: {}
+  #-------------------------------
+  # Reusable parameters
+  #-------------------------------
+  parameters:
+    RequestPathCdrArrangementId:
+      name: cdrArrangementId
+      description: Used to identify the consent arrangement from which to identify the bank and consumer information required to fetch the data.
+      in: path
+      required: true
+      schema:
+        type: string
+        example: 998621c8-1e1d-44ca-826e-754b910e5697
+    RequestPathAccountId:
+      name: accountId
+      in: path
+      description: A tokenised identifier for the account which is unique but not shareable
+      required: true
+      schema:
+        type: string
+        x-cds-type: ASCIIString
+        example: d9e75179-104f-47cf-9d29-18284222bab0
+      x-cds-type: ASCIIString
+    RequestPathDataHolderBrandId:
+      name: dataHolderBrandId
+      in: path
+      description: Used to identify the data holder from which to fetch the product data.
+      required: true
+      schema:
+        type: string
+        example: 55b3299a-3e50-48a2-a190-cca263ccaba5
+    RequestPathAccountIdPreviouslyListed:
+      name: accountId
+      in: path
+      description: ID of the account to get transactions for. Must have previously
+        been returned by one of the account list end points.
+      required: true
+      schema:
+        type: string
+        x-cds-type: ASCIIString
+        example: d9e75179-104f-47cf-9d29-18284222bab0
+      x-cds-type: ASCIIString
+    ParamAccountIds:
+      name: accountIds
+      in: query
+      description: Adatree's extension to support account ids for GET /accounts/balances
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific accountIds to obtain authorisations for
+          example: d9e75179-104f-47cf-9d29-18284222bab0
+          x-cds-type: ASCIIString
+    ParamProductCategory:
+      name: product-category
+      in: query
+      description: Used to filter results on the productCategory field applicable to accounts.
+        Any one of the valid values for this field can be supplied. If absent then all accounts returned.
+      required: false
+      schema:
+        type: string
+        example: BUSINESS_LOANS
+        enum:
+          - BUSINESS_LOANS
+          - CRED_AND_CHRG_CARDS
+          - LEASES
+          - MARGIN_LOANS
+          - OVERDRAFTS
+          - PERS_LOANS
+          - REGULATED_TRUST_ACCOUNTS
+          - RESIDENTIAL_MORTGAGES
+          - TERM_DEPOSITS
+          - TRADE_FINANCE
+          - TRAVEL_CARDS
+          - TRANS_AND_SAVINGS_ACCOUNTS
+    ParamAccountIsOwned:
+      name: is-owned
+      in: query
+      description: Filters accounts based on whether they are owned by the authorised customer.
+        True for owned accounts, false for unowned accounts and absent for all accounts
+      schema:
+        type: boolean
+        example: true
+        x-cds-type: Boolean
+    ParamDataHolderIds:
+      name: data-holder-ids
+      in: query
+      description: Array of strings used to identify the data holder from which to fetch the product/outage/status data.
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          example: 55b3299a-3e50-48a2-a190-cca263ccaba5
+    ParamPage:
+      name: page
+      in: query
+      description: Page of results to request (standard pagination)
+      schema:
+        type: integer
+        format: int32
+        default: 1
+        minimum: 1
+        example: 1
+        x-cds-type: PositiveInteger
+    ParamPageSize:
+      name: page-size
+      in: query
+      description: Page size to request. Default is 25 (standard pagination)
+      schema:
+        type: integer
+        default: 25
+        minimum: 1
+        maximum: 1000
+        example: 25
+        x-cds-type: PositiveInteger
+    ParamAccountOpenStatus:
+      name: open-status
+      in: query
+      description: Used to filter results according to open/closed status.
+        Values can be OPEN, CLOSED or ALL. If absent then ALL is assumed
+      required: false
+      schema:
+        type: string
+        example: OPEN
+        default: ALL
+        enum:
+          - OPEN
+          - CLOSED
+          - ALL
+    RequestHeader_x-v:
+      name: x-v
+      in: header
+      description: Version of the API end point requested by the client. Must be set
+        to a positive integer. The data holder should respond with the highest supported
+        version between [x-min-v](#request-headers) and [x-v](#request-headers). If
+        the value of [x-min-v](#request-headers) is equal to or higher than the value
+        of [x-v](#request-headers) then the [x-min-v](#request-headers) header should
+        be treated as absent. If all versions requested are not supported then the
+        data holder must respond with a 406 Not Acceptable. See [HTTP Headers](#request-headers)
+      required: true
+      schema:
+        type: string
+    RequestHeader_x-min-v:
+      name: x-min-v
+      in: header
+      description: Minimum version of the API end point requested by the client. Must
+        be set to a positive integer if provided. The data holder should respond with
+        the highest supported version between [x-min-v](#request-headers) and [x-v](#request-headers).
+        If all versions requested are not supported then the data holder must respond
+        with a 406 Not Acceptable.
+      schema:
+        type: string
+    RequestHeader_x-fapi-interaction-id:
+      name: x-fapi-interaction-id
+      in: header
+      description: An [RFC4122](https://tools.ietf.org/html/rfc4122) UUID used as
+        a correlation id. If provided, the data holder must play back this value in
+        the x-fapi-interaction-id response header. If not provided a [RFC4122] UUID
+        value is required to be provided in the response header to track the interaction.
+      schema:
+        type: string
+    RequestHeader_x-fapi-auth-date:
+      name: x-fapi-auth-date
+      in: header
+      description: The time when the customer last logged in to the data recipient. Required for all
+        resource calls from a machine client. Format is "HTTP-date" as in section "7.1.1.1" of RFC7231,
+        e.g., "Tue, 11 Sep 2012 19:43:31 GMT"
+      schema:
+        type: string
+        example: 'Tue, 11 Sep 2012 19:43:31 GMT'
+    RequestHeader_x-fapi-customer-ip-address:
+      name: x-fapi-customer-ip-address
+      in: header
+      description: The customer's original IP address if the customer is currently
+        logged in to the data recipient. The presence of this header indicates that
+        the API is being called in a customer present context. Not to be included
+        for unauthenticated calls.
+      schema:
+        type: string
+        example: 127.0.0.1
+    RequestHeader_x-cds-client-headers:
+      name: x-cds-client-headers
+      in: header
+      description: The customer's original standard http headers [Base64](#common-field-types)
+        encoded, including the original User Agent header, if the customer is currently
+        logged in to the data recipient. Mandatory for customer present calls.  Not
+        required for unattended or unauthenticated calls.
+        Format of this field is unclear and might be defined in future as discussed in https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/104
+      schema:
+        type: string
+        x-cds-type: Base64
+      x-cds-type: Base64
+    ParamTransactionNewestTime:
+      name: newest-time
+      in: query
+      description: Constrain the transaction history request to transactions with
+        effective time at or before this date/time.  If absent defaults to today.  Format
+        is aligned to DateTimeString common type
+      schema:
+        type: string
+        x-cds-type: DateTimeString
+      x-cds-type: DateTimeString
+    ParamTransactionOldestTime:
+      name: oldest-time
+      in: query
+      description: Constrain the transaction history request to transactions with
+        effective time at or after this date/time. If absent defaults to newest-time
+        minus 90 days.  Format is aligned to DateTimeString common type
+      schema:
+        type: string
+        x-cds-type: DateTimeString
+      x-cds-type: DateTimeString
+    ParamTransactionMinAmount:
+      name: min-amount
+      in: query
+      description: Filter transactions to only transactions with amounts higher or
+        equal to than this amount
+      schema:
+        type: string
+        x-cds-type: AmountString
+      x-cds-type: AmountString
+    ParamTransactionMaxAmount:
+      name: max-amount
+      in: query
+      description: Filter transactions to only transactions with amounts less than
+        or equal to than this amount
+      schema:
+        type: string
+        example: "10.00"
+        x-cds-type: AmountString
+      x-cds-type: AmountString
+    ParamTransactionText:
+      name: text
+      in: query
+      description: Filter transactions to only transactions where this string value
+        is found as a substring of either the reference or description fields. Format
+        is arbitrary ASCII string. This parameter is optionally implemented by data
+        holders. If it is not implemented then a response should be provided as normal
+        without text filtering applied and an additional boolean field named isQueryParamUnsupported
+        should be included in the meta object and set to true (whether the text parameter
+        is supplied or not)
+      schema:
+        type: string
+        example: milk
+  #-------------------------------
+  # Reusable responses
+  #-------------------------------
+  responses:
+    401Unauthorised:
+      description: Unauthorised
+    403Forbidden:
+      description: Forbidden
+    404NotFound:
+      description: The specified resource was not found.
+    400BadRequest:
+      description: Request is invalid
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ResponseErrorList'
+    424FailedDependency:
+      description: A downstream call to the ADH failed
+    429RateLimited:
+      description: Ratelimit reached
+    GenericError:
+      description: An error occurred.
+      content:
+        application/json:
+          schema:
+            type: string
+            example: something went wrong

--- a/draft/banking.yaml
+++ b/draft/banking.yaml
@@ -1607,10 +1607,18 @@ components:
           type: string
           description: Minimum transaction value that can be converted into an instalment plan
           x-cds-type: AmountString
+        minimumPlanValueCurrency:
+          type: string
+          description: If absent assumes AUD
+          x-cds-type: CurrencyString
         maximumPlanValue:
           type: string
           description: Maximum transaction value that can be converted into an instalment plan
           x-cds-type: AmountString
+        maximumPlanValueCurrency:
+          type: string
+          description: If absent assumes AUD
+          x-cds-type: CurrencyString
         minimumSplit:
           type: integer
           description: Minimum number of instalments allowed
@@ -2997,6 +3005,38 @@ components:
           type: string
           description: Purpose of the payment.  Format is defined by NPP standards for the x2p1.01 overlay service
           example: payment-purpose-npp
+    NppPaymentService:
+      type: string
+      description: Identifier of the applicable overlay service. The service is used in conjunction with the serviceVersion.
+      enum:
+        - X2P1
+        - IFTI
+        - BSCT
+        - CATSCT
+      example: X2P1
+    BankingTransactionDetail_extendedData_nppPayload:
+      type: object
+      required:
+        - extendedDescription
+      properties:
+        extendedDescription:
+          type: string
+          description: An extended string description. Only present if specified by the extensionUType field `nppPayload`
+          example: extended description of a transaction
+        endToEndId:
+          type: string
+          description: An end to end ID for the payment created at initiation
+          example: end-to-endid-for-payment
+        purposeCode:
+          type: string
+          description: Purpose of the payment. Format is defined by the NPP standards for the NPP overlay services including Osko (X2P1)
+          example: payment-purpose-npp
+        service:
+          $ref: '#/components/schemas/NppPaymentService'
+        serviceVersion:
+          type: string
+          description: Two-digit NPP service overlay version with leading zero.
+          example: '03'
     BankingTransactionDetail_extendedData:
       required:
         - service
@@ -3012,14 +3052,17 @@ components:
         extensionUType:
           type: string
           description: Optional extended data provided specific to transaction originated via NPP
-          example: x2p101Payload
+          example: nppPayload
           enum:
             - x2p101Payload
+            - nppPayload
         x2p101Payload:
           $ref: '#/components/schemas/BankingTransactionDetail_extendedData_x2p101Payload'
+        nppPayload:
+          $ref: '#/components/schemas/BankingTransactionDetail_extendedData_nppPayload'
         service:
           type: string
-          description: 'Identifier of the applicable overlay service. Valid values are: X2P1.01'
+          description: 'Identifier of the applicable overlay service. Valid values are: X2P1.01.'
           example: X2P1.01
           enum:
             - X2P1.01

--- a/draft/data.yaml
+++ b/draft/data.yaml
@@ -2326,7 +2326,6 @@ components:
               items:
                 $ref: '#/components/schemas/BankingProductLendingRateV2'
             instalments:
-              description: Instalment options available for this lending product
               $ref: '#/components/schemas/BankingProductInstalments'
     BankingProductBundle:
       type: object
@@ -5982,10 +5981,12 @@ components:
             $ref: '#/components/schemas/EnergyPlanDetail_allOf_meteringCharges'
         gasContract:
           description: "v2: Updated Gas Contract details"
-          $ref: '#/components/schemas/EnergyPlanContractV2'
+          allOf:
+            - $ref: '#/components/schemas/EnergyPlanContractV2'
         electricityContract:
           description: "v2: Updated Electricity Contract details"
-          $ref: '#/components/schemas/EnergyPlanContractV2'
+          allOf:
+            - $ref: '#/components/schemas/EnergyPlanContractV2'
       required:
         - fuelType
       type: object

--- a/draft/data.yaml
+++ b/draft/data.yaml
@@ -1,0 +1,6679 @@
+openapi: 3.0.1
+info:
+  title: Adatree ADR Platform Data API
+  description: |-
+    Adatree's Accredited Data Recipient (ADR) Platform Data API definition. Includes Banking and Energy.
+  contact:
+    name: Adatree Pty Ltd
+    url: https://adatree.com.au
+    email: support@adatree.com.au
+  version: "2.0.0"
+servers:
+  - url: https://cdr-insights-prod.api.adatree.com.au
+paths:
+  /data/banking/accounts:
+    get:
+      security:
+        - bearerAuth: [ 'data:banking:accounts:read' ]
+      tags:
+        - Banking
+      summary: Get Banking Accounts
+      description: |-
+        Obtain the list of banking accounts that consumers have consented to share across all data holders
+      operationId: getBankingAccounts
+      parameters:
+        - $ref: '#/components/parameters/QueryUseCaseIds'
+        - $ref: '#/components/parameters/QueryCdrArrangementIds'
+        - $ref: '#/components/parameters/QueryConsentIds'
+        - $ref: '#/components/parameters/QueryConsumerIds'
+        - $ref: '#/components/parameters/QueryAccountIds'
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryAccountIsOwned'
+        - $ref: '#/components/parameters/QueryAccountOpenStatus'
+        - $ref: '#/components/parameters/QueryProductCategory'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+        - $ref: '#/components/parameters/HeaderConsumerAuthDate'
+        - $ref: '#/components/parameters/HeaderConsumerIpAddress'
+        - $ref: '#/components/parameters/HeaderUserAgent'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/BankingAccountList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /data/banking/transactions:
+    get:
+      security:
+        - bearerAuth: [ 'data:banking:transactions:read' ]
+      tags:
+        - Banking
+      summary: Get Banking Transactions
+      description: |-
+        Obtain the list of banking transactions that consumers have consented to share across all data holders
+      operationId: getBankingTransactions
+      parameters:
+        - $ref: '#/components/parameters/QueryUseCaseIds'
+        - $ref: '#/components/parameters/QueryAccountIds'
+        - $ref: '#/components/parameters/QueryCdrArrangementIds'
+        - $ref: '#/components/parameters/QueryConsentIds'
+        - $ref: '#/components/parameters/QueryConsumerIds'
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryTransactionTypes'
+        - $ref: '#/components/parameters/QueryTransactionStatuses'
+        - $ref: '#/components/parameters/QueryTransactionMinimumAmount'
+        - $ref: '#/components/parameters/QueryTransactionMaximumAmount'
+        - $ref: '#/components/parameters/QueryTransactionOldestRetrievalTime'
+        - $ref: '#/components/parameters/QueryTransactionNewestRetrievalTime'
+        - $ref: '#/components/parameters/QueryTransactionOldestTime'
+        - $ref: '#/components/parameters/QueryTransactionNewestTime'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/BankingTransactionList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /data/banking/payees:
+    get:
+      security:
+        - bearerAuth: [ 'data:banking:payees:read' ]
+      tags:
+        - Banking
+      summary: Get Banking Payees
+      description: |-
+        Obtain the list of banking payees that consumers have consented to share across all data holders
+      operationId: getBankingPayees
+      parameters:
+        - $ref: '#/components/parameters/QueryUseCaseIds'
+        - $ref: '#/components/parameters/QueryCdrArrangementIds'
+        - $ref: '#/components/parameters/QueryConsentIds'
+        - $ref: '#/components/parameters/QueryConsumerIds'
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryPayeeTypes'
+        - $ref: '#/components/parameters/QueryPayeeIds'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/BankingPayeeList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /data/banking/payments/direct-debits:
+    get:
+      security:
+        - bearerAuth: [ 'data:banking:regular_payments:read' ]
+      tags:
+        - Banking
+      summary: Get Banking Direct Debits
+      description: |-
+        Obtain the list of banking direct debits that consumers have consented to share across all data holders
+      operationId: getBankingDirectDebits
+      parameters:
+        - $ref: '#/components/parameters/QueryUseCaseIds'
+        - $ref: '#/components/parameters/QueryCdrArrangementIds'
+        - $ref: '#/components/parameters/QueryConsentIds'
+        - $ref: '#/components/parameters/QueryConsumerIds'
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryAccountIds'
+        - $ref: '#/components/parameters/QueryAccountIsOwned'
+        - $ref: '#/components/parameters/QueryAccountOpenStatus'
+        - $ref: '#/components/parameters/QueryProductCategory'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/BankingDirectDebitAuthorisationList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /data/banking/payments/scheduled:
+    get:
+      security:
+        - bearerAuth: [ 'data:banking:regular_payments:read' ]
+      tags:
+        - Banking
+      summary: Get Scheduled Payments
+      description: |-
+        Obtain the list of banking scheduled payments that consumers have consented to share across all data holders
+      operationId: getScheduledPayments
+      parameters:
+        - $ref: '#/components/parameters/QueryUseCaseIds'
+        - $ref: '#/components/parameters/QueryCdrArrangementIds'
+        - $ref: '#/components/parameters/QueryConsentIds'
+        - $ref: '#/components/parameters/QueryConsumerIds'
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryAccountIds'
+        - $ref: '#/components/parameters/QueryAccountIsOwned'
+        - $ref: '#/components/parameters/QueryAccountOpenStatus'
+        - $ref: '#/components/parameters/QueryProductCategory'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/BankingScheduledPaymentsList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /data/banking/products:
+    get:
+      security:
+        - bearerAuth: [ 'adr:banking:read' ]
+      tags:
+        - Banking
+      summary: Get Banking Products
+      description: |-
+        Obtain the list of banking products across all data holders in banking industry
+      operationId: getBankingProducts
+      parameters:
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryProductCategory'
+        - $ref: '#/components/parameters/QueryProductIds'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/BankingProductList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /data/common/customers:
+    get:
+      security:
+        - bearerAuth: [ 'data:common:customers:read' ]
+      tags:
+        - Common
+      summary: Get Customers
+      description: Obtain a list of consumers that have consented to share across all data holders
+      operationId: getCustomers
+      parameters:
+        - $ref: '#/components/parameters/QueryUseCaseIds'
+        - $ref: '#/components/parameters/QueryCdrArrangementIds'
+        - $ref: '#/components/parameters/QueryConsentIds'
+        - $ref: '#/components/parameters/QueryConsumerIds'
+        - $ref: '#/components/parameters/QueryAccountIds'
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryCustomerUTypes'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseCommonCustomerList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /data/energy/accounts:
+    get:
+      deprecated: true
+      security:
+        - bearerAuth: [ 'data:energy:accounts:read' ]
+      tags:
+        - Energy
+      summary: Get Energy Accounts
+      description: |-
+        Obtain the list of energy accounts that consumers have consented to share across all data holders
+        Deprecated; use GET /data/v2/energy/accounts instead.
+      operationId: getEnergyAccounts
+      parameters:
+        - $ref: '#/components/parameters/QueryUseCaseIds'
+        - $ref: '#/components/parameters/QueryCdrArrangementIds'
+        - $ref: '#/components/parameters/QueryConsentIds'
+        - $ref: '#/components/parameters/QueryConsumerIds'
+        - $ref: '#/components/parameters/QueryAccountIds'
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/EnergyAccountList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /data/v2/energy/accounts:
+    get:
+      security:
+        - bearerAuth: [ 'data:energy:accounts:read' ]
+      tags:
+        - Energy
+      summary: Get Energy Accounts
+      description: |-
+        Obtain the list of energy accounts that consumers have consented to share across all data holders
+      operationId: getEnergyAccountsV2
+      parameters:
+        - $ref: '#/components/parameters/QueryUseCaseIds'
+        - $ref: '#/components/parameters/QueryCdrArrangementIds'
+        - $ref: '#/components/parameters/QueryConsentIds'
+        - $ref: '#/components/parameters/QueryConsumerIds'
+        - $ref: '#/components/parameters/QueryAccountIds'
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/EnergyAccountListV2'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /data/energy/invoices:
+    get:
+      security:
+        - bearerAuth: [ 'data:energy:invoices:read' ]
+      tags:
+        - Energy
+      summary: Get Energy Invoices
+      description: |-
+        Obtain the list of energy invoices that consumers have consented to share across all data holders
+      operationId: getEnergyInvoices
+      parameters:
+        - $ref: '#/components/parameters/QueryUseCaseIds'
+        - $ref: '#/components/parameters/QueryCdrArrangementIds'
+        - $ref: '#/components/parameters/QueryConsentIds'
+        - $ref: '#/components/parameters/QueryConsumerIds'
+        - $ref: '#/components/parameters/QueryAccountIds'
+        - $ref: '#/components/parameters/QueryInvoiceIds'
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/EnergyInvoiceList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /data/energy/bills:
+    get:
+      security:
+        - bearerAuth: [ 'data:energy:billing:read' ]
+      tags:
+        - Energy
+      summary: Get Energy Bills
+      description: |-
+        Obtain the list of energy bills that consumers have consented to share across all data holders
+      operationId: getEnergyBills
+      parameters:
+        - $ref: '#/components/parameters/QueryUseCaseIds'
+        - $ref: '#/components/parameters/QueryCdrArrangementIds'
+        - $ref: '#/components/parameters/QueryConsentIds'
+        - $ref: '#/components/parameters/QueryConsumerIds'
+        - $ref: '#/components/parameters/QueryAccountIds'
+        - $ref: '#/components/parameters/QueryBillingIds'
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/EnergyBillingList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /data/energy/electricity/servicepoints:
+    get:
+      security:
+        - bearerAuth: [ 'data:energy:electricity.servicepoints:read' ]
+      tags:
+        - Energy
+      summary: Get Electricity Service Points
+      description: |-
+        Obtain the list of energy service points that consumers have consented to share across all data holders
+      operationId: getEnergyElectricityServicePoints
+      parameters:
+        - $ref: '#/components/parameters/QueryUseCaseIds'
+        - $ref: '#/components/parameters/QueryCdrArrangementIds'
+        - $ref: '#/components/parameters/QueryConsentIds'
+        - $ref: '#/components/parameters/QueryConsumerIds'
+        - $ref: '#/components/parameters/QueryServicePointIds'
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/EnergyServicePointList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+  /data/energy/electricity/usage:
+    get:
+      security:
+        - bearerAuth: [ 'data:energy:electricity.usage:read' ]
+      tags:
+        - Energy
+      summary: Get Electricity Usage
+      description: |-
+        Obtain the list of electricity usage records that consumers have consented to share across all data holders. 
+        Provide Adatree-Consumer-Auth-Date, Adatree-Consumer-Ip-Address, Adatree-Consumer-User-Agent headers and consumerId parameter with exactly one value 
+        to trigger a realtime data update
+      operationId: getEnergyElectricityUsage
+      parameters:
+        - $ref: '#/components/parameters/QueryUseCaseIds'
+        - $ref: '#/components/parameters/QueryCdrArrangementIds'
+        - $ref: '#/components/parameters/QueryConsentIds'
+        - $ref: '#/components/parameters/QueryConsumerIds'
+        - $ref: '#/components/parameters/QueryServicePointIds'
+        - $ref: '#/components/parameters/QueryDataHolderBrandIds'
+        - $ref: '#/components/parameters/QueryPage'
+        - $ref: '#/components/parameters/QueryPageSize'
+        - $ref: '#/components/parameters/QueryOldestDate'
+        - $ref: '#/components/parameters/QueryNewestDate'
+        - $ref: '#/components/parameters/HeaderConsumerAuthDate'
+        - $ref: '#/components/parameters/HeaderConsumerIpAddress'
+        - $ref: '#/components/parameters/HeaderUserAgent'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/EnergyUsageList'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        401:
+          $ref: '#/components/responses/401Unauthorised'
+        403:
+          $ref: '#/components/responses/403Forbidden'
+        429:
+          $ref: '#/components/responses/429RateLimited'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    #-------------------------------
+    # Banking Response Schema Definitions
+    #-------------------------------
+    BankingTransactionList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/BankingTransactionList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    BankingAccountList:
+      type: object
+      required:
+        - data
+        - errors
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/BankingAccountList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    BankingPayeeList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/BankingPayeeList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    BankingProductList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/BankingProductList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    BankingDirectDebitAuthorisationList:
+      properties:
+        data:
+          $ref: '#/components/schemas/BankingDirectDebitAuthorisationList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+      required:
+        - data
+        - links
+        - meta
+      type: object
+    BankingScheduledPaymentsList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/BankingScheduledPaymentsList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    BankingAccountList_data:
+      type: object
+      required:
+        - accounts
+      properties:
+        accounts:
+          type: array
+          description: The list of accounts returned. If the filter results in an empty set then this array may have no records
+          items:
+            $ref: '#/components/schemas/BankingAccountDetail'
+    BankingPayeeList_data:
+      type: object
+      required:
+        - payees
+      properties:
+        payees:
+          type: array
+          items:
+            $ref: '#/components/schemas/BankingPayeeDetail'
+    BankingProductList_data:
+      type: object
+      required:
+        - products
+      properties:
+        products:
+          type: array
+          items:
+            $ref: '#/components/schemas/BankingProductDetail'
+    BankingDirectDebitAuthorisationList_data:
+      type: object
+      required:
+        - directDebitAuthorisations
+      properties:
+        directDebitAuthorisations:
+          description: The list of authorisations returned
+          items:
+            $ref: '#/components/schemas/BankingDirectDebit'
+          type: array
+    BankingScheduledPaymentsList_data:
+      type: object
+      required:
+        - scheduledPayments
+      properties:
+        scheduledPayments:
+          type: array
+          description: The list of scheduled payments to return
+          items:
+            $ref: '#/components/schemas/BankingScheduledPayment'
+    BankingScheduledPayment:
+      type: object
+      required:
+        - from
+        - payeeReference
+        - payerReference
+        - paymentSet
+        - recurrence
+        - scheduledPaymentId
+        - status
+        - adatree
+      properties:
+        scheduledPaymentId:
+          type: string
+          description: A unique ID of the scheduled payment adhering to the standards for ID permanence
+          example: f632041c-d7c8-4679-a165-aa406cd62b13
+        nickname:
+          type: string
+          example: council
+          description: The short display name of the payee as provided by the customer
+        payerReference:
+          type: string
+          example: 1231234142
+          description: The reference for the transaction that will be used by the originating institution for the purposes of constructing a statement narrative on the payer's account. Empty string if no data provided
+        payeeReference:
+          type: string
+          example: 234134241234
+          description: The reference for the transaction that will be provided by the originating institution. Empty string if no data provided
+        status:
+          type: string
+          example: ACTIVE
+          description: Indicates whether the schedule is currently active. The value SKIP is equivalent to ACTIVE except that the customer has requested the next normal occurrence to be skipped.
+          enum:
+            - ACTIVE
+            - INACTIVE
+            - SKIP
+        from:
+          $ref: '#/components/schemas/BankingScheduledPaymentFrom'
+        paymentSet:
+          type: array
+          items:
+            $ref: '#/components/schemas/BankingScheduledPaymentSet'
+        recurrence:
+          $ref: '#/components/schemas/BankingScheduledPaymentRecurrence'
+        adatree:
+          $ref: '#/components/schemas/Adatree'
+    BankingScheduledPaymentSet:
+      type: object
+      required:
+        - to
+      properties:
+        to:
+          $ref: '#/components/schemas/BankingScheduledPaymentTo'
+        isAmountCalculated:
+          type: boolean
+          example: true
+          description: Flag indicating whether the amount of the payment is calculated based on the context of the event. For instance a payment to reduce the balance of a credit card to zero. If absent then false is assumed
+        amount:
+          type: string
+          example: 123.00
+          description: The amount of the next payment if known. Mandatory unless the isAmountCalculated field is set to true. Must be zero or positive if present
+        currency:
+          type: string
+          example: AUD
+          description: The currency for the payment. AUD assumed if not present
+      description: The set of payment amounts and destination accounts for this payment accommodating multi-part payments. A single entry indicates a simple payment with one destination account. Must have at least one entry
+      x-conditional:
+        - amount
+    BankingScheduledPaymentTo:
+      type: object
+      required:
+        - toUType
+      properties:
+        toUType:
+          type: string
+          description: The type of object provided that specifies the destination of the funds for the payment.
+          example: payeeId
+          enum:
+            - accountId
+            - payeeId
+            - domestic
+            - biller
+            - digitalWallet
+            - international
+        accountId:
+          type: string
+          example: ""
+          description: Present if toUType is set to accountId. Indicates that the payment is to another account that is accessible under the current consent
+        payeeId:
+          type: string
+          example: f632041c-d7c8-4679-a165-aa406cd62b13
+          description: Present if toUType is set to payeeId. Indicates that the payment is to registered payee that can be accessed using the payee end point. If the Bank Payees scope has not been consented to then a payeeId should not be provided and the full payee details should be provided instead
+        domestic:
+          $ref: '#/components/schemas/BankingDomesticPayee'
+        biller:
+          $ref: '#/components/schemas/BankingBillerPayee'
+        digitalWallet:
+          $ref: '#/components/schemas/BankingDigitalWalletPayee'
+        international:
+          $ref: '#/components/schemas/BankingInternationalPayee'
+      description: Object containing details of the destination of the payment. Used to specify a variety of payment destination types
+      x-conditional:
+        - accountId
+        - payeeId
+        - domestic
+        - biller
+        - digitalWallet
+        - international
+    BankingScheduledPaymentFrom:
+      type: object
+      required:
+        - accountId
+      properties:
+        accountId:
+          type: string
+          example: f632041c-d7c8-4679-a165-aa406cd62b13
+          description: ID of the account that is the source of funds for the payment
+      description: Object containing details of the source of the payment. Currently only specifies an account ID but provided as an object to facilitate future extensibility and consistency with the to object
+    BankingScheduledPaymentRecurrence:
+      type: object
+      required:
+        - recurrenceUType
+      properties:
+        nextPaymentDate:
+          type: string
+          example: "2017-12-31"
+          description: The date of the next payment under the recurrence schedule
+        recurrenceUType:
+          type: string
+          description: The type of recurrence used to define the schedule
+          example: onceOff
+          enum:
+            - onceOff
+            - intervalSchedule
+            - lastWeekDay
+            - eventBased
+        onceOff:
+          $ref: '#/components/schemas/BankingScheduledPaymentRecurrenceOnceOff'
+        intervalSchedule:
+          $ref: '#/components/schemas/BankingScheduledPaymentRecurrenceIntervalSchedule'
+        lastWeekDay:
+          $ref: '#/components/schemas/BankingScheduledPaymentRecurrenceLastWeekday'
+        eventBased:
+          $ref: '#/components/schemas/BankingScheduledPaymentRecurrenceEventBased'
+      description: Object containing the detail of the schedule for the payment
+      x-conditional:
+        - onceOff
+        - intervalSchedule
+        - lastWeekDay
+        - eventBased
+    BankingScheduledPaymentRecurrenceOnceOff:
+      type: object
+      required:
+        - paymentDate
+      properties:
+        paymentDate:
+          type: string
+          example: "2017-12-31"
+          description: The scheduled date for the once off payment
+      description: Indicates that the payment is a once off payment on a specific future date. Mandatory if recurrenceUType is set to onceOff
+    BankingScheduledPaymentRecurrenceIntervalSchedule:
+      type: object
+      required:
+        - intervals
+      properties:
+        finalPaymentDate:
+          type: string
+          example: "2017-12-31"
+          description: The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+        paymentsRemaining:
+          type: integer
+          example: 12
+          description: Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value, If neither field is present the payments will continue indefinitely
+        nonBusinessDayTreatment:
+          type: string
+          example: AFTER
+          description: Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+          default: 'ON'
+          enum:
+            - 'AFTER'
+            - 'BEFORE'
+            - 'ON'
+            - 'ONLY'
+        intervals:
+          type: array
+          description: An array of interval objects defining the payment schedule.  Each entry in the array is additive, in that it adds payments to the overall payment schedule.  If multiple intervals result in a payment on the same day then only one payment will be made. Must have at least one entry
+          items:
+            $ref: '#/components/schemas/BankingScheduledPaymentInterval'
+      description: Indicates that the schedule of payments is defined by a series of intervals. Mandatory if recurrenceUType is set to intervalSchedule
+    BankingScheduledPaymentInterval:
+      type: object
+      required:
+        - interval
+      properties:
+        interval:
+          type: string
+          example: P1D
+          description: An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+        dayInInterval:
+          type: string
+          example: ""
+          description: Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
+    BankingScheduledPaymentRecurrenceLastWeekday:
+      type: object
+      required:
+        - interval
+        - lastWeekDay
+      properties:
+        finalPaymentDate:
+          type: string
+          example: "2017-12-31"
+          description: The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+        paymentsRemaining:
+          type: integer
+          description: Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+          example: 12
+        interval:
+          type: string
+          description: The interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+          example: P1D
+        lastWeekDay:
+          type: string
+          example: MON
+          description: The weekDay specified. The payment will occur on the last occurrence of this weekday in the interval.
+          enum:
+            - MON
+            - TUE
+            - WED
+            - THU
+            - FRI
+            - SAT
+            - SUN
+        nonBusinessDayTreatment:
+          type: string
+          description: Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+          example: AFTER
+          default: 'ON'
+          enum:
+            - 'AFTER'
+            - 'BEFORE'
+            - 'ON'
+            - 'ONLY'
+      description: Indicates that the schedule of payments is defined according to the last occurrence of a specific weekday in an interval. Mandatory if recurrenceUType is set to lastWeekDay
+    BankingScheduledPaymentRecurrenceEventBased:
+      type: object
+      required:
+        - description
+      properties:
+        description:
+          type: string
+          example: pay every Thursday
+          description: Description of the event and conditions that will result in the payment. Expected to be formatted for display to a customer
+      description: Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if recurrenceUType is set to eventBased
+    #-------------------------------
+    # Energy Response Schema Definitions
+    #-------------------------------
+    EnergyAccountList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/EnergyAccountList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    EnergyAccountListV2:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/EnergyAccountListV2_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+    EnergyAccountList_data:
+      required:
+        - accounts
+      properties:
+        accounts:
+          type: array
+          description: The list of energy accounts returned. If the filter results in an empty set then this array may have no records
+          items:
+            $ref: '#/components/schemas/EnergyAccountDetailV2'
+    EnergyAccountListV2_data:
+      type: object
+      required:
+        - accounts
+      properties:
+        accounts:
+          type: array
+          description: The list of energy accounts returned. If the filter results in an empty set then this array may have no records
+          items:
+            $ref: '#/components/schemas/EnergyAccountDetailV3'
+
+    #-------------------------------
+    # Banking Schema Definitions
+    #-------------------------------
+    BankingAccount:
+      type: object
+      required:
+        - accountId
+        - displayName
+        - maskedNumber
+        - productCategory
+        - productName
+      properties:
+        accountId:
+          type: string
+          example: d9e75179-104f-47cf-9d29-18284222bab0
+          description: A unique ID of the account adhering to the standards for ID permanence
+        creationDate:
+          type: string
+          example: "2012-12-25"
+          description: Date that the account was created (if known)
+        displayName:
+          type: string
+          example: savings
+          description: The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
+        nickname:
+          type: string
+          example: sav
+          description: A customer supplied nickname for the account
+        openStatus:
+          type: string
+          example: OPEN
+          description: Open or closed status for the account. If not present then OPEN is assumed
+          default: OPEN
+          enum:
+            - OPEN
+            - CLOSED
+        isOwned:
+          type: boolean
+          example: true
+          description: Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
+          default: true
+        accountOwnership:
+          type: string
+          description: Value indicating the number of customers that have ownership of the account, according to the data holder's definition of account ownership. Does not indicate that all account owners are eligible consumers
+          enum:
+            - UNKNOWN
+            - ONE_PARTY
+            - TWO_PARTY
+            - MANY_PARTY
+            - OTHER
+        maskedNumber:
+          type: string
+          example: "xxx-xxx xxxxx1234"
+          description: A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
+        productCategory:
+          $ref: '#/components/schemas/BankingProductCategory'
+        productName:
+          type: string
+          example: Savings
+          description: The unique identifier of the account as defined by the data holder (akin to model number for the account)
+    BankingAccountDetail:
+      allOf:
+        - $ref: '#/components/schemas/BankingAccount'
+        - type: object
+          properties:
+            bsb:
+              type: string
+              example: 062000
+              description: The unmasked BSB for the account. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
+            accountNumber:
+              example: 12345678
+              type: string
+              description: The unmasked account number for the account. Should not be supplied if the account number is a PAN requiring PCI compliance. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
+            balance:
+              $ref: '#/components/schemas/BankingBalance'
+            bundleName:
+              type: string
+              example: ""
+              description: Optional field to indicate if this account is part of a bundle that is providing additional benefit for to the customer
+            specificAccountUType:
+              type: string
+              example: termDeposit
+              description: The type of structure to present account specific fields.
+              enum:
+                - termDeposit
+                - creditCard
+                - loan
+            termDeposit:
+              type: array
+              items:
+                $ref: '#/components/schemas/BankingTermDepositAccount'
+            creditCard:
+              $ref: '#/components/schemas/BankingCreditCardAccount'
+            loan:
+              $ref: '#/components/schemas/BankingLoanAccount'
+            depositRate:
+              type: string
+              example: 2.20
+              description: current rate to calculate interest earned being applied to deposit balances as it stands at the time of the API call
+            lendingRate:
+              type: string
+              example: 3.19
+              description: The current rate to calculate interest payable being applied to lending balances as it stands at the time of the API call
+            depositRates:
+              type: array
+              description: Fully described deposit rates for this account based on the equivalent structure in Product Reference
+              items:
+                $ref: '#/components/schemas/BankingProductDepositRate'
+            lendingRates:
+              type: array
+              description: Fully described deposit rates for this account based on the equivalent structure in Product Reference
+              items:
+                $ref: '#/components/schemas/BankingProductLendingRateV2'
+            features:
+              type: array
+              description: Array of features of the account based on the equivalent structure in Product Reference with the following additional field
+              items:
+                $ref: '#/components/schemas/BankingAccountProductFeature'
+            fees:
+              type: array
+              description: Fees and charges applicable to the account based on the equivalent structure in Product Reference
+              items:
+                $ref: '#/components/schemas/BankingProductFee'
+            addresses:
+              type: array
+              description: The addresses for the account to be used for correspondence
+              items:
+                $ref: '#/components/schemas/CommonPhysicalAddress'
+            isInstalmentDetailAvailable:
+              type: boolean
+              default: false
+              description: True if any active or inactive instalment plans are available in the instalment plan endpoints. False if instalment plans are not applicable to the account
+            instalments:
+              $ref: '#/components/schemas/BankingProductInstalments'
+            adatree:
+              $ref: '#/components/schemas/BankingAccountDetail_adatree'
+          x-conditional:
+            - termDeposit
+            - creditCard
+            - loan
+    BankingAccountProductFeature:
+      type: object
+      description: Array of features of the account based on the equivalent structure in Product Reference with the following additional field
+      allOf:
+        - $ref: '#/components/schemas/BankingProductFeature'
+        - type: object
+          properties:
+            isActivated:
+              type: boolean
+              description: True if the feature is already activated and false if the feature is available for activation. (note this is an additional field appended to the feature object defined in the Product Reference payload)
+              example: true
+    BankingTermDepositAccount:
+      type: object
+      required:
+        - lodgementDate
+        - maturityDate
+        - maturityInstructions
+      properties:
+        lodgementDate:
+          type: string
+          example: "2017-12-31"
+          description: The lodgement date of the original deposit
+        maturityDate:
+          type: string
+          example: "2018-12-30"
+          description: Maturity date for the term deposit
+        maturityAmount:
+          type: string
+          example: "10000.00"
+          description: Amount to be paid upon maturity. If absent it implies the amount to paid is variable and cannot currently be calculated
+        maturityCurrency:
+          type: string
+          example: AUD
+          description: If absent assumes AUD
+        maturityInstructions:
+          type: string
+          example: ROLLED_OVER
+          description: Current instructions on action to be taken at maturity. This includes default actions that may be specified in the terms and conditions for the product e.g. roll-over to the same term and frequency of interest payments
+          enum:
+            - ROLLED_OVER
+            - PAID_OUT_AT_MATURITY
+            - HOLD_ON_MATURITY
+    BankingCreditCardAccount:
+      type: object
+      required:
+        - minPaymentAmount
+        - paymentDueAmount
+        - paymentDueDate
+      properties:
+        minPaymentAmount:
+          type: string
+          example: 99.99
+          description: The minimum payment amount due for the next card payment
+        paymentDueAmount:
+          type: string
+          example: 2999.99
+          description: The amount due for the next card payment
+        paymentCurrency:
+          type: string
+          example: AUD
+          description: If absent assumes AUD
+        paymentDueDate:
+          type: string
+          example: "2021-01-01"
+          description: Date that the next payment for the card is due
+    BankingLoanAccount:
+      type: object
+      properties:
+        originalStartDate:
+          type: string
+          example: "2017-12-31"
+          description: Optional original start date for the loan
+        originalLoanAmount:
+          type: string
+          example: 300000.00
+          description: Optional original loan value
+        originalLoanCurrency:
+          type: string
+          example: AUD
+          description: If absent assumes AUD
+          default: AUD
+        loanEndDate:
+          type: string
+          example: "2047-12-30"
+          description: Date that the loan is due to be repaid in full
+        nextInstalmentDate:
+          type: string
+          example: "2021-02-28"
+          description: Next date that an instalment is required
+        minInstalmentAmount:
+          type: string
+          example: 999.99
+          description: Minimum amount of next instalment
+        minInstalmentCurrency:
+          type: string
+          example: AUD
+          description: If absent assumes AUD
+          default: AUD
+        maxRedraw:
+          type: string
+          example: 9999.99
+          description: Maximum amount of funds that can be redrawn. If not present redraw is not available even if the feature exists for the account
+        maxRedrawCurrency:
+          type: string
+          example: AUD
+          description: If absent assumes AUD
+          default: AUD
+        minRedraw:
+          type: string
+          example: 1000
+          description: Minimum redraw amount
+        minRedrawCurrency:
+          type: string
+          example: AUD
+          description: If absent assumes AUD
+          default: AUD
+        offsetAccountEnabled:
+          type: boolean
+          example: true
+          description: Set to true if one or more offset accounts are configured for this loan account
+        offsetAccountIds:
+          type: array
+          description: The accountIDs of the configured offset accounts attached to this loan. Only offset accounts that can be accessed under the current authorisation should be included.
+          items:
+            example: ["f632041c-d7c8-4679-a165-aa406cd62b13"]
+            type: string
+        repaymentType:
+          type: string
+          description: Options in place for repayments. If absent defaults to PRINCIPAL_AND_INTEREST
+          example: INTEREST_ONLY
+          default: PRINCIPAL_AND_INTEREST
+          enum:
+            - INTEREST_ONLY
+            - OTHER
+            - PRINCIPAL_AND_INTEREST
+            - UNCONSTRAINED
+        repaymentFrequency:
+          type: string
+          example: P1M
+          description: The expected or required repayment frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+    BankingBalance:
+      type: object
+      required:
+        - availableBalance
+        - currentBalance
+      properties:
+        currentBalance:
+          type: string
+          example: "10000.00"
+          description: The balance of the account at this time. Should align to the balance available via other channels such as Internet Banking. Assumed to be negative if the customer has money owing
+        availableBalance:
+          type: string
+          example: "10000.00"
+          description: Balance representing the amount of funds available for transfer. Assumed to be zero or positive
+        creditLimit:
+          type: string
+          example: "10000.00"
+          description: Object representing the maximum amount of credit that is available for this account. Assumed to be zero if absent
+        amortisedLimit:
+          type: string
+          example: "0.00"
+          description: Object representing the available limit amortised according to payment schedule. Assumed to be zero if absent
+        currency:
+          type: string
+          example: AUD
+          description: The currency for the balance amounts. If absent assumed to be AUD
+        purses:
+          type: array
+          description: Optional array of balances for the account in other currencies. Included to support accounts that support multi-currency purses such as Travel Cards
+          items:
+            $ref: '#/components/schemas/BankingBalancePurse'
+        refreshDateTime:
+          type: string
+          description: Most recent refresh date time stamp
+    BankingBalancePurse:
+      type: object
+      required:
+        - amount
+      properties:
+        amount:
+          type: string
+          example: "1000.00"
+          description: The balance available for this additional currency purse
+        currency:
+          type: string
+          example: AUD
+          description: The currency for the purse
+    BankingProductCategory:
+      type: string
+      description: The category to which a product or account belongs. See [here](#product-categories) for more details
+      example: LEASES
+      enum:
+        - BUSINESS_LOANS
+        - BUY_NOW_PAY_LATER
+        - CRED_AND_CHRG_CARDS
+        - LEASES
+        - MARGIN_LOANS
+        - OVERDRAFTS
+        - PERS_LOANS
+        - REGULATED_TRUST_ACCOUNTS
+        - RESIDENTIAL_MORTGAGES
+        - TERM_DEPOSITS
+        - TRADE_FINANCE
+        - TRAVEL_CARDS
+        - TRANS_AND_SAVINGS_ACCOUNTS
+    NppPaymentService:
+      type: string
+      description: Identifier of the applicable overlay service. The service is used in conjunction with the serviceVersion.
+      enum:
+        - X2P1
+        - IFTI
+        - BSCT
+        - CATSCT
+      example: X2P1
+    BankingProductDepositRate:
+      type: object
+      required:
+        - depositRateType
+        - rate
+      properties:
+        depositRateType:
+          type: string
+          example: FIXED
+          description: The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
+          enum:
+            - BONUS
+            - BUNDLE_BONUS
+            - FIXED
+            - FLOATING
+            - INTRODUCTORY
+            - MARKET_LINKED
+            - VARIABLE
+        rate:
+          type: string
+          example: 2.50
+          description: The rate to be applied
+        calculationFrequency:
+          type: string
+          example: P1M
+          description: The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+        applicationType:
+          type: string
+          description: The method used to apply the calculated amount
+          enum:
+            - MATURITY
+            - PERIODIC
+            - UPFRONT
+        applicationFrequency:
+          type: string
+          example: P1M
+          description: The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+        tiers:
+          type: array
+          description: Rate tiers applicable for this rate
+          items:
+            $ref: '#/components/schemas/BankingProductRateTierV3'
+        applicabilityConditionList:
+          type: array
+          description: Applicability conditions for the rate
+          items:
+            $ref: '#/components/schemas/BankingProductRateCondition'
+        additionalValue:
+          type: string
+          example: additional value for deposit rate
+          description: Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
+        additionalInfo:
+          type: string
+          example: additional info for deposit rate
+          description: Display text providing more information on the rate
+        additionalInfoUri:
+          type: string
+          example: https://depositrate.example.com.au
+          description: Link to a web page with more information on this rate
+      x-conditional:
+        - additionalValue
+    BankingProductLendingRateV2:
+      type: object
+      required:
+        - lendingRateType
+        - rate
+      properties:
+        lendingRateType:
+          type: string
+          description: The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
+          example: CASH_ADVANCE
+          enum:
+            - BALANCE_TRANSFER
+            - BUNDLE_DISCOUNT_FIXED
+            - BUNDLE_DISCOUNT_VARIABLE
+            - CASH_ADVANCE
+            - DISCOUNT
+            - FLOATING
+            - INTRODUCTORY
+            - MARKET_LINKED
+            - PENALTY
+            - PURCHASE
+            - VARIABLE
+            - FIXED
+        rate:
+          type: string
+          example: 3.99
+          description: The rate to be applied
+        comparisonRate:
+          type: string
+          example: 4.99
+          description: A comparison rate equivalent for this rate
+        calculationFrequency:
+          type: string
+          example: P1M
+          description: The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+        applicationType:
+          type: string
+          description: The method used to apply the calculated amount
+          enum:
+            - MATURITY
+            - PERIODIC
+            - UPFRONT
+        applicationFrequency:
+          type: string
+          example: P1M
+          description: The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+        interestPaymentDue:
+          type: string
+          example: IN_ARREARS
+          description: When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
+          enum:
+            - IN_ADVANCE
+            - IN_ARREARS
+        repaymentType:
+          type: string
+          example: INTEREST_ONLY
+          description: Options in place for repayments. If absent, the lending rate is applicable to all repayment types
+          enum:
+            - INTEREST_ONLY
+            - OTHER
+            - PRINCIPAL_AND_INTEREST
+            - UNCONSTRAINED
+        loanPurpose:
+          type: string
+          example: OWNER_OCCUPIED
+          description: The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
+          enum:
+            - OTHER
+            - OWNER_OCCUPIED
+            - INVESTMENT
+            - UNCONSTRAINED
+        tiers:
+          type: array
+          description: Rate tiers applicable for this rate
+          items:
+            $ref: '#/components/schemas/BankingProductRateTierV3'
+        applicabilityConditionList:
+          type: array
+          description: Applicability conditions for the rate
+          items:
+            $ref: '#/components/schemas/BankingProductRateCondition'
+        additionalValue:
+          type: string
+          example: additional value for lending
+          description: Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
+        additionalInfo:
+          type: string
+          example: additional info for lending
+          description: Display text providing more information on the rate.
+        additionalInfoUri:
+          type: string
+          example: https://lendingrate.example.com.au
+          description: Link to a web page with more information on this rate
+      x-conditional:
+        - additionalValue
+    BankingProductFee:
+      type: object
+      required:
+        - feeType
+        - name
+      properties:
+        name:
+          type: string
+          description: Name of the fee
+          example: account fee
+        feeType:
+          type: string
+          description: The type of fee
+          example: PERIODIC
+          enum:
+            - CASH_ADVANCE
+            - DEPOSIT
+            - DISHONOUR
+            - ENQUIRY
+            - EVENT
+            - EXIT
+            - LATE_PAYMENT
+            - OTHER
+            - PAYMENT
+            - PERIODIC
+            - PURCHASE
+            - REPLACEMENT
+            - TRANSACTION
+            - UPFRONT
+            - UPFRONT_PER_PLAN
+            - VARIABLE
+            - VARIATION
+            - WITHDRAWAL
+        feeMethodUType:
+          type: string
+          description: The method used to calculate the fee
+          enum:
+            - fixedAmount
+            - rateBased
+            - variable
+        fixedAmount:
+          $ref: '#/components/schemas/BankingFeeAmount'
+        rateBased:
+          $ref: '#/components/schemas/BankingFeeRate'
+        variable:
+          $ref: '#/components/schemas/BankingFeeRange'
+        feeCap:
+          type: string
+          description: The maximum total amount charged for a fee over a period
+          example: "10.00"
+        feeCapPeriod:
+          type: string
+          description: The period over which a fee cap applies. Formatted according to ISO 8601 Durations
+          example: P1M
+        currency:
+          type: string
+          description: The currency the fee will be charged in. Assumes AUD if absent
+          example: AUD
+        additionalValue:
+          type: string
+          description: Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
+          example: additional info for bank account fee
+        additionalInfo:
+          type: string
+          description: Display text providing more information on the fee
+          example: additional info on the fee
+        additionalInfoUri:
+          type: string
+          description: Link to a web page with more information on this fee
+          example: https://bankfee.example.com.au
+        discounts:
+          type: array
+          description: An optional list of discounts to this fee that may be available
+          items:
+            $ref: '#/components/schemas/BankingProductDiscount'
+      x-conditional:
+        - additionalValue
+    BankingFeeAmount:
+      type: object
+      properties:
+        amount:
+          type: string
+          description: Fixed fee amount
+          example: "4.00"
+    BankingFeeRate:
+      type: object
+      properties:
+        rate:
+          type: string
+          description: Generic fee rate
+          example: "3.99"
+        rateType:
+          type: string
+          description: The type of rate used to calculate the fee or discount
+          enum:
+            - BALANCE
+            - TRANSACTION
+            - INTEREST_ACCRUED
+            - FEE
+        accrualFrequency:
+          type: string
+          description: The indicative frequency with which the fee is calculated on the account. Formatted according to ISO 8601 Durations
+          example: P1M
+        amountRange:
+          $ref: '#/components/schemas/BankingFeeRange'
+    BankingFeeDiscountRate:
+      type: object
+      properties:
+        rate:
+          type: string
+          description: Generic discount rate
+          example: "3.99"
+        rateType:
+          type: string
+          description: The type of rate used to calculate the discount
+          enum:
+            - BALANCE
+            - TRANSACTION
+            - INTEREST_ACCRUED
+            - FEE
+        amountRange:
+          $ref: '#/components/schemas/BankingFeeDiscountRange'
+    BankingFeeRange:
+      type: object
+      properties:
+        feeMinimum:
+          type: string
+          description: The minimum amount for which the range applies
+          example: "0.00"
+        feeMaximum:
+          type: string
+          description: The maximum amount for which the range applies
+          example: "100.00"
+    BankingFeeDiscountRange:
+      type: object
+      properties:
+        discountMinimum:
+          type: string
+          description: The minimum discount amount for which the range applies
+          example: "0.00"
+        discountMaximum:
+          type: string
+          description: The maximum discount amount for which the range applies
+          example: "100.00"
+    CommonPhysicalAddress:
+      type: object
+      required:
+        - addressUType
+      properties:
+        addressUType:
+          type: string
+          description: The type of address object present
+          example: simple
+          enum:
+            - simple
+            - paf
+        simple:
+          $ref: '#/components/schemas/CommonSimpleAddress'
+        paf:
+          $ref: '#/components/schemas/CommonPAFAddress'
+      x-conditional:
+        - simple
+        - paf
+    BankingProductFeature:
+      type: object
+      required:
+        - featureType
+      properties:
+        featureType:
+          type: string
+          description: The type of feature described
+          example: BONUS_REWARDS
+          enum:
+            - ADDITIONAL_CARDS
+            - BALANCE_TRANSFERS
+            - BILL_PAYMENT
+            - BONUS_REWARDS
+            - CARD_ACCESS
+            - CASHBACK_OFFER
+            - COMPLEMENTARY_PRODUCT_DISCOUNTS
+            - EXTRA_DOWN_PAYMENT
+            - DIGITAL_BANKING
+            - DIGITAL_WALLET
+            - DONATE_INTEREST
+            - EXTRA_REPAYMENTS
+            - FRAUD_PROTECTION
+            - FREE_TXNS
+            - FREE_TXNS_ALLOWANCE
+            - FUNDS_AVAILABLE_AFTER
+            - GUARANTOR
+            - INSURANCE
+            - INSTALMENT_PLAN
+            - INTEREST_FREE
+            - INTEREST_FREE_TRANSFERS
+            - LOYALTY_PROGRAM
+            - NOTIFICATIONS
+            - NPP_ENABLED
+            - NPP_PAYID
+            - OFFSET
+            - OTHER
+            - OVERDRAFT
+            - REDRAW
+            - RELATIONSHIP_MANAGEMENT
+            - UNLIMITED_TXNS
+        additionalValue:
+          type: string
+          description: Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
+          example: free mobile device screen smash insurance
+        additionalInfo:
+          type: string
+          description: Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
+          example: the best of a kind
+        additionalInfoUri:
+          type: string
+          description: Link to a web page with more information on this feature
+          example: https://productfeature.example.com.au
+      x-conditional:
+        - additionalValue
+        - additionalInfo
+    BankingProductRateTierV3:
+      type: object
+      required:
+        - minimumValueString
+        - name
+        - unitOfMeasure
+      properties:
+        name:
+          type: string
+          example: basic
+          description: A display name for the tier
+        unitOfMeasure:
+          type: string
+          example: MONTH
+          description: The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+          enum:
+            - DOLLAR
+            - PERCENT
+            - DAY
+            - MONTH
+        minimumValueString:
+          type: string
+          example: "1"
+          description: String representation of the lower bound of the tier
+        maximumValueString:
+          type: string
+          example: "3"
+          description: String representation of the upper bound of the tier
+        rateApplicationMethod:
+          type: string
+          description: The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+          example: PER_TIER
+          enum:
+            - PER_TIER
+            - WHOLE_BALANCE
+        applicabilityConditionList:
+          type: array
+          description: Conditions for the applicability of the tiered rate
+          items:
+            $ref: '#/components/schemas/BankingProductRateCondition'
+        additionalInfo:
+          type: string
+          example: additional info for tier
+          description: Display text providing more information on the rate tier.
+        additionalInfoUri:
+          type: string
+          example: https://tier.example.com.au
+          description: Link to a web page with more information on this rate tier
+      description: Defines the criteria and conditions for which a rate applies
+    BankingProductDiscount:
+      type: object
+      required:
+        - description
+        - discountType
+      properties:
+        description:
+          type: string
+          example: loyalty discount
+          description: Description of the discount
+        discountType:
+          type: string
+          example: ELIGIBILITY_ONLY
+          description: The type of discount. See the next section for an overview of valid values and their meaning
+          enum:
+            - BALANCE
+            - DEPOSITS
+            - ELIGIBILITY_ONLY
+            - FEE_CAP
+            - PAYMENTS
+        discountMethodUType:
+          type: string
+          description: The method used to calculate the discount
+          enum:
+            - FIXED_AMOUNT
+            - RATE_BASED
+        fixedAmount:
+          $ref: '#/components/schemas/BankingFeeAmount'
+        rateBased:
+          $ref: '#/components/schemas/BankingFeeDiscountRate'
+        additionalValue:
+          type: string
+          example: extra discount
+          description: Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
+        additionalInfo:
+          type: string
+          example: addition info for discount
+          description: Display text providing more information on the discount
+        additionalInfoUri:
+          type: string
+          example: https://productdiscount.example.com.au
+          description: Link to a web page with more information on this discount
+        eligibility:
+          type: array
+          description: Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
+          items:
+            $ref: '#/components/schemas/BankingProductDiscountEligibility'
+      x-conditional:
+        - additionalValue
+        - eligibility
+    CommonSimpleAddress:
+      type: object
+      required:
+        - addressLine1
+        - city
+        - state
+      properties:
+        mailingName:
+          type: string
+          description: Name of the individual or business formatted for inclusion in an address used for physical mail
+          example: John Doe
+        addressLine1:
+          type: string
+          description: First line of the standard address object
+          example: 1 Pitt ST
+        addressLine2:
+          type: string
+          description: Second line of the standard address object
+          example: ""
+        addressLine3:
+          type: string
+          description: Third line of the standard address object
+          example: ""
+        postcode:
+          type: string
+          description: Mandatory for Australian addresses
+          example: 2000
+        city:
+          type: string
+          description: Name of the city or locality
+          example: SYDNEY
+        state:
+          type: string
+          description: Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+          example: NSW
+        country:
+          type: string
+          description: A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+          example: AUS
+          default: AUS
+      x-conditional:
+        - postcode
+    CommonPAFAddress:
+      type: object
+      required:
+        - localityName
+        - postcode
+        - state
+      properties:
+        dpid:
+          type: string
+          description: Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+          example: 17160
+        thoroughfareNumber1:
+          type: integer
+          description: Thoroughfare number for a property (first number in a property ranged address)
+          example: 16
+        thoroughfareNumber1Suffix:
+          type: string
+          description: Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+          example: ""
+        thoroughfareNumber2:
+          type: integer
+          description: Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+          example: 19
+        thoroughfareNumber2Suffix:
+          type: string
+          description: Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+          example: ""
+        flatUnitType:
+          type: string
+          description: Type of flat or unit for the address
+          example: unit
+        flatUnitNumber:
+          type: string
+          description: Unit number (including suffix, if applicable)
+          example: 10
+        floorLevelType:
+          type: string
+          description: Type of floor or level for the address
+          example: level
+        floorLevelNumber:
+          type: string
+          description: Floor or level number (including alpha characters)
+          example: 3
+        lotNumber:
+          type: string
+          description: Allotment number for the address
+          example: 10
+        buildingName1:
+          type: string
+          description: Building/Property name 1
+          example: summer
+        buildingName2:
+          type: string
+          description: Building/Property name 2
+          example: ""
+        streetName:
+          type: string
+          description: The name of the street
+          example: Long
+        streetType:
+          type: string
+          description: The street type. Valid enumeration defined by Australia Post PAF code file
+          example: ST
+        streetSuffix:
+          type: string
+          description: The street type suffix. Valid enumeration defined by Australia Post PAF code file
+        postalDeliveryType:
+          type: string
+          description: Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+          example: PO BOX
+        postalDeliveryNumber:
+          type: integer
+          description: Postal delivery number if the address is a postal delivery type
+          example: 15
+        postalDeliveryNumberPrefix:
+          type: string
+          description: Postal delivery number prefix related to the postal delivery number
+          example: ""
+        postalDeliveryNumberSuffix:
+          type: string
+          description: Postal delivery number suffix related to the postal delivery number
+          example: ""
+        localityName:
+          type: string
+          description: Full name of locality
+          example: "Sydney"
+        postcode:
+          type: string
+          description: Postcode for the locality
+          example: 2000
+        state:
+          type: string
+          description: State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+          example: NSW
+      description: Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+    BankingProductRateCondition:
+      type: object
+      properties:
+        rateApplicabilityType:
+          type: string
+          description: The type of rate applicability condition described
+          enum:
+            - MIN_DEPOSITS
+            - MIN_DEPOSIT_AMOUNT
+            - DEPOSIT_BALANCE_INCREASED
+            - EXISTING_CUST
+            - NEW_ACCOUNTS
+            - NEW_CUSTOMER
+            - NEW_CUSTOMER_TO_GROUP
+            - ONLINE_ONLY
+            - OTHER
+            - MIN_PURCHASES
+            - MAX_WITHDRAWALS
+            - MAX_WITHDRAWAL_AMOUNT
+        additionalValue:
+          type: string
+          description: Generic field containing additional information relevant to the rate applicability condition
+        additionalInfo:
+          type: string
+          example: additional info for rate condition
+          description: Display text providing more information on the condition
+        additionalInfoUri:
+          type: string
+          description: Link to a web page with more information on this condition
+          example: https://ratecondition.example.com.au
+      description: Defines a condition for the applicability of a tiered rate
+    BankingProductDiscountEligibility:
+      type: object
+      required:
+        - discountEligibilityType
+      properties:
+        discountEligibilityType:
+          type: string
+          example: "STAFF"
+          description: The type of the specific eligibility constraint for a discount
+          enum:
+            - BUSINESS
+            - EMPLOYMENT_STATUS
+            - INTRODUCTORY
+            - MAX_AGE
+            - MIN_AGE
+            - MIN_INCOME
+            - MIN_TURNOVER
+            - NATURAL_PERSON
+            - PENSION_RECIPIENT
+            - RESIDENCY_STATUS
+            - STAFF
+            - STUDENT
+            - OTHER
+        additionalValue:
+          type: string
+          example: additional value for discount eligibility
+          description: Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+        additionalInfo:
+          type: string
+          example: additional info for discount eligibility
+          description: Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+        additionalInfoUri:
+          type: string
+          example: https://discounteligibility.example.com.au
+          description: Link to a web page with more information on this eligibility constraint
+      x-conditional:
+        - additionalInfo
+        - additionalValue
+    LinksPaginated:
+      type: object
+      required:
+        - self
+      properties:
+        self:
+          type: string
+          description: Fully qualified link that generated the current response document.
+            https://self.example.com.au will be converted to https://self.example.com.au?page=1&page-size=25
+          example: https://self.example.com.au?page=3&page-size=25
+        first:
+          type: string
+          description: URI to the first page of this set. Mandatory if this response is not the first page
+          example: https://self.example.com.au?page=1&page-size=25
+        prev:
+          type: string
+          description: URI to the previous page of this set. Mandatory if this response is not the first page
+          example: https://self.example.com.au?page=2&page-size=25
+        next:
+          type: string
+          description: URI to the next page of this set. Mandatory if this response is not the last page
+          example: https://self.example.com.au?page=4&page-size=25
+        last:
+          type: string
+          description: URI to the last page of this set. Mandatory if this response is not the last page
+          example: https://self.example.com.au?page=15&page-size=25
+      x-conditional:
+        - prev
+        - next
+        - first
+        - last
+    MetaPaginated:
+      type: object
+      required:
+        - totalPages
+        - totalRecords
+      properties:
+        totalRecords:
+          type: integer
+          description: The total number of records in the full set. See [pagination](#pagination).
+          example: 581
+        totalPages:
+          type: integer
+          description: The total number of pages in the full set. See [pagination](#pagination).
+          example: 24
+    ErrorList:
+      type: object
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ErrorList_errors'
+    BankingTransactionList_data:
+      type: object
+      required:
+        - transactions
+      properties:
+        transactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/BankingTransaction'
+    BankingTransaction:
+      type: object
+      required:
+        - accountId
+        - amount
+        - description
+        - isDetailAvailable
+        - reference
+        - status
+        - type
+      properties:
+        accountId:
+          type: string
+          example: f632041c-d7c8-4679-a165-aa406cd62b13
+          description: ID of the account for which transactions are provided
+        transactionId:
+          type: string
+          example: f111111-d7c8-4679-a165-aa406cd62b13
+          description: A unique ID of the transaction adhering to the standards for ID permanence.  This is mandatory (through hashing if necessary) unless there are specific and justifiable technical reasons why a transaction cannot be uniquely identified for a particular account type
+        isDetailAvailable:
+          type: boolean
+          example: true
+          description: True if extended information is available using the transaction detail end point. False if extended data is not available
+        type:
+          type: string
+          example: FEE
+          description: The type of the transaction
+          enum:
+            - DIRECT_DEBIT
+            - FEE
+            - INTEREST_CHARGED
+            - INTEREST_PAID
+            - PAYMENT
+            - TRANSFER_OUTGOING
+            - TRANSFER_INCOMING
+            - OTHER
+        status:
+          type: string
+          example: POSTED
+          description: Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction
+          enum:
+            - PENDING
+            - POSTED
+        description:
+          example: banking fee
+          type: string
+          description: The transaction description as applied by the financial institution
+        postingDateTime:
+          type: string
+          example: "2021-01-12T15:43:00.121Z"
+          description: The time the transaction was posted. This field is Mandatory if the transaction has status POSTED.  This is the time that appears on a standard statement.
+            DateTimeString can be found at https://consumerdatastandardsaustralia.github.io/standards/#common-field-types
+        valueDateTime:
+          type: string
+          example: "2021-01-12T15:43:00.121Z"
+          description: Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry
+        executionDateTime:
+          type: string
+          example: "2021-01-12T15:43:00.121Z"
+          description: The time the transaction was executed by the originating customer, if available
+        amount:
+          type: string
+          example: 100.00
+          description: The value of the transaction. Negative values mean money was outgoing from the account
+        currency:
+          type: string
+          example: AUD
+          description: The currency for the transaction amount. AUD assumed if not present
+        reference:
+          type: string
+          example: overdraw
+          description: The reference for the transaction provided by the originating institution. Empty string if no data provided
+        merchantName:
+          type: string
+          example: McDonald
+          description: Name of the merchant for an outgoing payment to a merchant
+        merchantCategoryCode:
+          type: string
+          example: RANDOM
+          description: The merchant category code (or MCC) for an outgoing payment to a merchant
+        billerCode:
+          type: string
+          example: 234213427384923
+          description: BPAY Biller Code for the transaction (if available)
+        billerName:
+          type: string
+          example: test biller
+          description: Name of the BPAY biller for the transaction (if available)
+        crn:
+          type: string
+          example: 1234asdf1
+          description: BPAY CRN for the transaction (if available)
+        apcaNumber:
+          type: string
+          example: 111111
+          description: 6 Digit APCA number for the initiating institution. The field is fixed-width and padded with leading zeros if applicable.
+        extendedData:
+          $ref: '#/components/schemas/BankingTransaction_extendedData'
+        adatree:
+          $ref: '#/components/schemas/BankingTransaction_adatree'
+      x-conditional:
+        - transactionId
+        - postingDateTime
+    BankingTransaction_extendedData_x2p101Payload:
+      type: object
+      required:
+        - extendedDescription
+      properties:
+        extendedDescription:
+          type: string
+          description: An extended string description. Only present if specified by the extensionUType field
+          example: extended description of a transaction
+        endToEndId:
+          type: string
+          description: An end to end ID for the payment created at initiation
+          example: end-to-endid-for-payment
+        purposeCode:
+          type: string
+          description: Purpose of the payment.  Format is defined by NPP standards for the x2p1.01 overlay service
+          example: payment-purpose-npp
+    BankingTransaction_extendedData_nppPayload:
+      type: object
+      required:
+        - extendedDescription
+      properties:
+        extendedDescription:
+          type: string
+          description: An extended string description. Only present if specified by the extensionUType field `nppPayload`
+          example: extended description of a transaction
+        endToEndId:
+          type: string
+          description: An end to end ID for the payment created at initiation
+          example: end-to-endid-for-payment
+        purposeCode:
+          type: string
+          description: Purpose of the payment. Format is defined by the NPP standards for the NPP overlay services including Osko (X2P1)
+          example: payment-purpose-npp
+        service:
+          $ref: '#/components/schemas/NppPaymentService'
+        serviceVersion:
+          type: string
+          description: Two-digit NPP service overlay version with leading zero.
+          example: '03'
+    BankingTransaction_extendedData:
+      type: object
+      required:
+        - service
+      properties:
+        payer:
+          type: string
+          description: Label of the originating payer. Mandatory for inbound payment
+          example: Jane Doe
+        payee:
+          type: string
+          description: Label of the target PayID.  Mandatory for an outbound payment. The name assigned to the BSB/Account Number or PayID (by the owner of the PayID)
+          example: John Doe
+        extensionUType:
+          type: string
+          description: Optional extended data provided specific to transaction originated via NPP
+          example: nppPayload
+          enum:
+            - nppPayload
+            - x2p101Payload
+        x2p101Payload:
+          $ref: '#/components/schemas/BankingTransaction_extendedData_x2p101Payload'
+        nppPayload:
+          $ref: '#/components/schemas/BankingTransaction_extendedData_nppPayload'
+        service:
+          type: string
+          description: 'Identifier of the applicable overlay service. Valid values are: X2P1.01'
+          example: X2P1.01
+          enum:
+            - X2P1.01
+    Adatree:
+      type: object
+      description: Extra data and metadata provided by Adatree
+      required:
+        - consentId
+        - consumerId
+        - cdrArrangementId
+        - dataHolderBrandId
+        - useCaseId
+      properties:
+        consentId:
+          type: string
+          example: 55b3299a-3e50-48a2-a190-cca263ccaba5
+          description: Consent Id for related resource
+        consumerId:
+          type: string
+          example: 55b3299a-3e50-48a2-a190-cca263ccaba5
+          description: Consumer Id for related resource
+        cdrArrangementId:
+          type: string
+          example: f111111-d7c8-4679-a165-aa406cd62b13
+          description: CDR Arrangement for related resource
+        dataHolderBrandId:
+          type: string
+          example: 55b3299a-3e50-48a2-a190-cca263ccaba5
+          description: Data Holder Brand Id for related resource
+        useCaseId:
+          type: string
+          example: HOME_LOAN
+          description: Use Case Id for related resource
+    BankingTransaction_adatree:
+      description: Extra data and metadata provided by Adatree for transactions
+      required:
+        - resourceId
+      allOf:
+        - $ref: '#/components/schemas/Adatree'
+        - type: object
+          properties:
+            resourceId:
+              type: string
+              example: f632041c-d7c8-4679-a165-aa406cd62b13
+              description: resource ID generated by Adatree; the ADHs do not always provide a transaction Id so we generate an id to uniquely identify a transaction
+    BankingAccountDetail_adatree:
+      description: Extra data and metadata provided by Adatree for accounts
+      required:
+        - errors
+      allOf:
+        - $ref: '#/components/schemas/Adatree'
+        - type: object
+          properties:
+            errors:
+              type: array
+              items:
+                $ref: '#/components/schemas/SecuredCdsDataApiError'
+    BankingPayee:
+      type: object
+      example:
+        nickname: nickname
+        description: description
+        payeeId: payeeId
+        type: BILLER
+        creationDate: creationDate
+      properties:
+        payeeId:
+          description: ID of the payee adhering to the rules of ID permanence
+          type: string
+        nickname:
+          description: The short display name of the payee as provided by the customer.
+            Where a customer has not provided a nickname, a display name derived by
+            the bank for the payee consistent with existing digital banking channels
+          type: string
+        description:
+          description: A description of the payee provided by the customer
+          type: string
+        type:
+          description: The type of payee.<br/>DOMESTIC means a registered payee for
+            domestic payments including NPP. <br/>INTERNATIONAL means a registered
+            payee for international payments. <br/>BILLER means a registered payee
+            for BPAY.
+            wallet
+          enum:
+            - BILLER
+            - DIGITAL_WALLET
+            - DOMESTIC
+            - INTERNATIONAL
+          type: string
+        creationDate:
+          description: The date the payee was created by the customer
+          type: string
+      required:
+        - nickname
+        - payeeId
+        - type
+    BankingProductDetail:
+      allOf:
+        - $ref: '#/components/schemas/BankingProductV3'
+        - type: object
+          properties:
+            bundles:
+              type: array
+              description: An array of bundles that this product participates in.  Each bundle is described by free form information but also by a list of product IDs of the other products that are included in the bundle.  It is assumed that the current product is included in the bundle also
+              items:
+                $ref: '#/components/schemas/BankingProductBundle'
+            features:
+              type: array
+              description: Array of features available for the product
+              items:
+                $ref: '#/components/schemas/BankingProductFeature'
+            constraints:
+              type: array
+              description: Constraints on the application for or operation of the product such as minimum balances or limit thresholds
+              items:
+                $ref: '#/components/schemas/BankingProductConstraint'
+            eligibility:
+              type: array
+              description: Eligibility criteria for the product
+              items:
+                $ref: '#/components/schemas/BankingProductEligibility'
+            fees:
+              type: array
+              description: Fees applicable for the product
+              items:
+                $ref: '#/components/schemas/BankingProductFee'
+            depositRates:
+              type: array
+              description: Interest rates available for deposits
+              items:
+                $ref: '#/components/schemas/BankingProductDepositRate'
+            lendingRates:
+              type: array
+              description: Interest rates charged against lending balances
+              items:
+                $ref: '#/components/schemas/BankingProductLendingRateV2'
+            instalments:
+              description: Instalment options available for this lending product
+              $ref: '#/components/schemas/BankingProductInstalments'
+    BankingProductBundle:
+      type: object
+      required:
+        - description
+        - name
+      properties:
+        name:
+          type: string
+          description: Name of the bundle
+          example: homeloanpackage
+        description:
+          type: string
+          description: Description of the bundle
+          example: a home loan package product
+        additionalInfo:
+          type: string
+          description: Display text providing more information on the bundle
+          example: extra info about the bundle product
+        additionalInfoUri:
+          type: string
+          description: Link to a web page with more information on the bundle criteria and benefits
+          example: https://extrainfo.homeloan.example.com.au
+        productIds:
+          type: array
+          description: Array of product IDs for products included in the bundle that are available via the product end points.  Note that this array is not intended to represent a comprehensive model of the products included in the bundle and some products available for the bundle may not be available via the product reference end points
+          example: [ "f632041c-d7c8-4679-a165-aa406cd62b13" ]
+          items:
+            type: string
+    BankingProductV3:
+      type: object
+      required:
+        - brand
+        - description
+        - isTailored
+        - lastUpdated
+        - name
+        - productCategory
+        - productId
+        - dataHolderId
+      properties:
+        productId:
+          type: string
+          description: A data holder specific unique identifier for this product. This identifier must be unique to a product but does not otherwise need to adhere to ID permanence guidelines.
+          example: f632041c-d7c8-4679-a165-aa406cd62b13
+        effectiveFrom:
+          type: string
+          description: The date and time from which this product is effective (ie. is available for origination).  Used to enable the articulation of products to the regime before they are available for customers to originate
+          example: "1997-01-12T15:43:00.121Z"
+        effectiveTo:
+          type: string
+          description: The date and time at which this product will be retired and will no longer be offered.  Used to enable the managed deprecation of products
+          example: "2007-05-01T15:43:00.12345Z"
+        lastUpdated:
+          type: string
+          description: The last date and time that the information for this product was changed (or the creation date for the product if it has never been altered)
+          example: "2019-01-12T15:43:00.121Z"
+        dataHolderId:
+          type: string
+          description: The id of data holder
+          example: "55b3299a-3e50-48a2-a190-cca263ccaba5"
+        dataHolderBrandName:
+          type: string
+          description: The brand name of data holder
+          example: "Red Australia Bank"
+        productCategory:
+          $ref: '#/components/schemas/BankingProductCategory'
+        name:
+          type: string
+          description: The display name of the product
+          example: Budgeting Insights
+        description:
+          type: string
+          description: A description of the product
+          example: Data will be used to advise you on how to manage your budget.
+        brand:
+          type: string
+          description: A label of the brand for the product. Able to be used for filtering. For data holders with single brands this value is still required
+          example: budgetinsights
+        brandName:
+          type: string
+          description: An optional display name of the brand
+          example: Smart Budget
+        brandGroup:
+          type: string
+          description: The data holder's brand group that this product belongs to
+          example: Major Bank Group
+        applicationUri:
+          type: string
+          description: A link to an application web page where this product can be applied for.
+          example: https://apply.smartbudgets.example.com.au
+        isTailored:
+          type: boolean
+          description: Indicates whether the product is specifically tailored to a circumstance.  In this case fees and prices are significantly negotiated depending on context. While all products are open to a degree of tailoring this flag indicates that tailoring is expected and thus that the provision of specific fees and rates is not applicable
+          example: true
+        additionalInformation:
+          $ref: '#/components/schemas/BankingProductV3_additionalInformation'
+        cardArt:
+          type: array
+          description: An array of card art images
+          items:
+            $ref: '#/components/schemas/BankingProductV3_cardArt'
+    BankingProductInstalments:
+      type: object
+      required:
+        - minimumSplit
+        - maximumSplit
+      properties:
+        maximumConcurrentPlans:
+          type: integer
+          description: Maximum number of instalment plans that can operate concurrently
+        instalmentsLimit:
+          type: string
+          description: Maximum total value of transactions that may be converted to instalments
+        minimumPlanValue:
+          type: string
+          description: Minimum value for an instalment plan
+        maximumPlanValue:
+          type: string
+          description: Maximum value for an instalment plan
+        minimumSplit:
+          type: integer
+          description: Minimum number of instalments allowed
+        maximumSplit:
+          type: integer
+          description: Maximum number of instalments allowed
+    BankingProductConstraint:
+      type: object
+      required:
+        - constraintType
+      properties:
+        constraintType:
+          type: string
+          description: The type of constraint described.  See the next section for an overview of valid values and their meaning
+          example: MAX_BALANCE
+          enum:
+            - MIN_BALANCE
+            - MIN_LIMIT
+            - MIN_LVR
+            - MAX_BALANCE
+            - MAX_LVR
+            - MAX_LIMIT
+            - OPENING_BALANCE
+            - OTHER
+        additionalValue:
+          type: string
+          description: Generic field containing additional information relevant to the [constraintType](#tocSproductconstrainttypedoc) specified.  Whether mandatory or not is dependent on the value of [constraintType](#tocSproductconstrainttypedoc)
+          example: no fees
+        additionalInfo:
+          type: string
+          description: Display text providing more information the constraint
+          example: no limit black card
+        additionalInfoUri:
+          type: string
+          description: Link to a web page with more information on the constraint
+          example: https://productconstraint.example.com.au
+      x-conditional:
+        - additionalValue
+    BankingProductEligibility:
+      type: object
+      required:
+        - eligibilityType
+      properties:
+        eligibilityType:
+          type: string
+          description: The type of eligibility criteria described.  See the next section for an overview of valid values and their meaning
+          example: BUSINESS
+          enum:
+            - BUSINESS
+            - EMPLOYMENT_STATUS
+            - MAX_AGE
+            - MIN_AGE
+            - MIN_INCOME
+            - MIN_TURNOVER
+            - NATURAL_PERSON
+            - PENSION_RECIPIENT
+            - RESIDENCY_STATUS
+            - STAFF
+            - STUDENT
+            - OTHER
+        additionalValue:
+          type: string
+          description: Generic field containing additional information relevant to the [eligibilityType](#tocSproducteligibilitytypedoc) specified. Whether mandatory or not is dependent on the value of [eligibilityType](#tocSproducteligibilitytypedoc)
+          example: additional value for product eligibility
+        additionalInfo:
+          type: string
+          description: Display text providing more information on the [eligibility](#tocSproducteligibilitytypedoc) criteria. Mandatory if the field is set to OTHER
+          example: additional info for product eligibility
+        additionalInfoUri:
+          type: string
+          description: Link to a web page with more information on this eligibility criteria
+          example: https://producteligibility.example.com.au
+      x-conditional:
+        - additionalValue
+        - additionalInfo
+    BankingProductV3_additionalInformation:
+      type: object
+      properties:
+        overviewUri:
+          type: string
+          description: General overview of the product
+          example: https://overview.example.com.au
+        termsUri:
+          type: string
+          description: Terms and conditions for the product
+          example: https://terms.example.com.au
+        eligibilityUri:
+          type: string
+          description: Eligibility rules and criteria for the product
+          example: https://eligiblity.example.com.au
+        feesAndPricingUri:
+          type: string
+          description: Description of fees, pricing, discounts, exemptions and bonuses for the product
+          example: https://feesandpricing.example.com.au
+        bundleUri:
+          type: string
+          description: Description of a bundle that this product can be part of
+          example: https://bundle.example.com.au
+        additionalOverviewUris:
+          type: array
+          description: An array of additional general overviews for the product or features of the product, if applicable. To be treated as secondary documents to the `overviewUri`. Only to be used if there is a primary `overviewUri`.
+          items:
+            $ref: '#/components/schemas/BankingProductAdditionalInformationV2_additionalInformationUris'
+        additionalTermsUris:
+          type: array
+          description: An array of additional terms and conditions for the product, if applicable. To be treated as secondary documents to the `termsUri`. Only to be used if there is a primary `termsUri`.
+          items:
+            $ref: '#/components/schemas/BankingProductAdditionalInformationV2_additionalInformationUris'
+        additionalEligibilityUris:
+          type: array
+          description: An array of additional eligibility rules and criteria for the product, if applicable. To be treated as secondary documents to the `eligibilityUri`. Only to be used if there is a primary `eligibilityUri`.
+          items:
+            $ref: '#/components/schemas/BankingProductAdditionalInformationV2_additionalInformationUris'
+        additionalFeesAndPricingUris:
+          type: array
+          description: An array of additional fees, pricing, discounts, exemptions and bonuses for the product, if applicable. To be treated as secondary documents to the `feesAndPricingUri`. Only to be used if there is a primary `feesAndPricingUri`.
+          items:
+            $ref: '#/components/schemas/BankingProductAdditionalInformationV2_additionalInformationUris'
+        additionalBundleUris:
+          type: array
+          description: An array of additional bundles for the product, if applicable. To be treated as secondary documents to the `bundleUri`. Only to be used if there is a primary `bundleUri`.
+          items:
+            $ref: '#/components/schemas/BankingProductAdditionalInformationV2_additionalInformationUris'
+      description: Object that contains links to additional information on specific topics
+    BankingProductAdditionalInformationV2_additionalInformationUris:
+      required:
+        - additionalInfoUri
+      type: object
+      properties:
+        description:
+          type: string
+          description: Display text providing more information about the document URI
+        additionalInfoUri:
+          type: string
+          description: The URI describing the additional information
+          x-cds-type: URIString
+    BankingProductV3_cardArt:
+      type: object
+      required:
+        - imageUri
+      properties:
+        title:
+          type: string
+          description: Display label for the specific image
+          example: title image
+        cardScheme:
+          type: string
+          description: The card scheme for the card image
+          enum:
+            - AMEX
+            - EFTPOS
+            - MASTERCARD
+            - VISA
+            - OTHER
+        cardType:
+          type: string
+          description: The type of card represented by the image
+          enum:
+            - CHARGE
+            - CREDIT
+            - DEBIT
+        imageUri:
+          type: string
+          description: URI reference to a PNG, JPG or GIF image with proportions defined by ISO 7810 ID-1 and width no greater than 512 pixels. The URI reference may be a link or url-encoded data URI [RFC 2397](https://tools.ietf.org/html/rfc2397)
+          example: https://image12345.example.com.au
+    BankingPayeeDetail:
+      allOf:
+        - $ref: '#/components/schemas/BankingPayee'
+        - $ref: '#/components/schemas/BankingPayeeDetail_allOf'
+        - type: object
+          properties:
+            adatree:
+              $ref: '#/components/schemas/Adatree'
+    BankingPayeeDetail_allOf:
+      properties:
+        payeeUType:
+          description: Type of object included that describes the payee in detail
+          enum:
+            - biller
+            - digitalWallet
+            - domestic
+            - international
+          type: string
+        biller:
+          $ref: '#/components/schemas/BankingBillerPayee'
+        digitalWallet:
+          $ref: '#/components/schemas/BankingDigitalWalletPayee'
+        domestic:
+          $ref: '#/components/schemas/BankingDomesticPayee'
+        international:
+          $ref: '#/components/schemas/BankingInternationalPayee'
+      required:
+        - payeeUType
+      type: object
+      x-conditional:
+        - biller
+        - domestic
+        - international
+    BankingBillerPayee:
+      example:
+        billerName: billerName
+        crn: crn
+        billerCode: billerCode
+      properties:
+        billerCode:
+          description: BPAY Biller Code of the Biller
+          type: string
+        crn:
+          description: BPAY CRN of the Biller (if available).<br/>Where the CRN contains
+            sensitive information, it should be masked in line with how the Data Holder
+            currently displays account identifiers in their existing online banking
+            channels. If the contents of the CRN match the format of a Credit Card
+            PAN they should be masked according to the rules applicable for MaskedPANString.
+            If the contents are otherwise sensitive, then it should be masked
+            using the rules applicable for the MaskedAccountString common type.
+          type: string
+        billerName:
+          description: Name of the Biller
+          type: string
+      required:
+        - billerCode
+        - billerName
+      type: object
+      x-conditional:
+        - crn
+    BankingDigitalWalletPayee:
+      required:
+        - identifier
+        - name
+        - provider
+        - type
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
+        identifier:
+          type: string
+          description: The identifier of the digital wallet (dependent on type)
+        type:
+          type: string
+          description: The type of the digital wallet identifier
+          enum:
+            - EMAIL
+            - CONTACT_NAME
+            - TELEPHONE
+        provider:
+          type: string
+          description: The provider of the digital wallet
+          enum:
+            - PAYPAL_AU
+            - OTHER
+    BankingInternationalPayee:
+      example:
+        bankDetails:
+          country: country
+          routingNumber: routingNumber
+          fedWireNumber: fedWireNumber
+          chipNumber: chipNumber
+          legalEntityIdentifier: legalEntityIdentifier
+          accountNumber: accountNumber
+          bankAddress:
+            address: address
+            name: name
+          sortCode: sortCode
+          beneficiaryBankBIC: beneficiaryBankBIC
+        beneficiaryDetails:
+          country: country
+          name: name
+          message: message
+      properties:
+        beneficiaryDetails:
+          $ref: '#/components/schemas/BankingInternationalPayee_beneficiaryDetails'
+        bankDetails:
+          $ref: '#/components/schemas/BankingInternationalPayee_bankDetails'
+      required:
+        - bankDetails
+        - beneficiaryDetails
+      type: object
+    BankingDomesticPayee:
+      example:
+        payeeAccountUType: account
+        payId:
+          identifier: identifier
+          name: name
+          type: ABN
+        account:
+          bsb: bsb
+          accountName: accountName
+          accountNumber: accountNumber
+        card:
+          cardNumber: cardNumber
+      properties:
+        payeeAccountUType:
+          description: 'Type of account object included. Valid values are: **account**
+                  A standard Australian account defined by BSB/Account Number. **card**
+                  A credit or charge card to pay to (note that PANs are masked). **payId**
+                  A PayID recognised by NPP'
+          enum:
+            - account
+            - card
+            - payId
+          type: string
+        account:
+          $ref: '#/components/schemas/BankingDomesticPayeeAccount'
+        card:
+          $ref: '#/components/schemas/BankingDomesticPayeeCard'
+        payId:
+          $ref: '#/components/schemas/BankingDomesticPayeePayId'
+      required:
+        - payeeAccountUType
+      type: object
+      x-conditional:
+        - account
+        - card
+        - payId
+    BankingDomesticPayeeAccount:
+      example:
+        bsb: bsb
+        accountName: accountName
+        accountNumber: accountNumber
+      properties:
+        accountName:
+          description: Name of the account to pay to
+          type: string
+        bsb:
+          description: BSB of the account to pay to
+          type: string
+        accountNumber:
+          description: Number of the account to pay to
+          type: string
+      required:
+        - accountNumber
+        - bsb
+      type: object
+    BankingDomesticPayeeCard:
+      example:
+        cardNumber: cardNumber
+      properties:
+        cardNumber:
+          description: Name of the account to pay to
+          type: string
+      required:
+        - cardNumber
+      type: object
+    BankingDomesticPayeePayId:
+      example:
+        identifier: identifier
+        name: name
+        type: ABN
+      properties:
+        name:
+          description: The name assigned to the PayID by the owner of the PayID
+          type: string
+        identifier:
+          description: The identifier of the PayID (dependent on type)
+          type: string
+        type:
+          description: The type of the PayID
+          enum:
+            - ABN
+            - EMAIL
+            - ORG_IDENTIFIER
+            - TELEPHONE
+          type: string
+      required:
+        - identifier
+        - type
+      type: object
+    BankingInternationalPayee_beneficiaryDetails:
+      example:
+        country: country
+        name: name
+        message: message
+      properties:
+        name:
+          description: Name of the beneficiary
+          type: string
+        country:
+          description: Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html)
+            country code
+          type: string
+        message:
+          description: Response message for the payment
+          type: string
+      required:
+        - country
+      type: object
+    BankingInternationalPayee_bankDetails_bankAddress:
+      example:
+        address: address
+        name: name
+      properties:
+        name:
+          description: Name of the recipient Bank
+          type: string
+        address:
+          description: Address of the recipient Bank
+          type: string
+      required:
+        - address
+        - name
+      type: object
+    BankingInternationalPayee_bankDetails:
+      example:
+        country: country
+        routingNumber: routingNumber
+        fedWireNumber: fedWireNumber
+        chipNumber: chipNumber
+        legalEntityIdentifier: legalEntityIdentifier
+        accountNumber: accountNumber
+        bankAddress:
+          address: address
+          name: name
+        sortCode: sortCode
+        beneficiaryBankBIC: beneficiaryBankBIC
+      properties:
+        country:
+          description: Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html)
+            country code
+          type: string
+        accountNumber:
+          description: Account Targeted for payment
+          type: string
+        bankAddress:
+          $ref: '#/components/schemas/BankingInternationalPayee_bankDetails_bankAddress'
+        beneficiaryBankBIC:
+          description: Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
+          type: string
+        fedWireNumber:
+          description: Number for Fedwire payment (Federal Reserve Wire Network)
+          type: string
+        sortCode:
+          description: Sort code used for account identification in some jurisdictions
+          type: string
+        chipNumber:
+          description: Number for the Clearing House Interbank Payments System
+          type: string
+        routingNumber:
+          description: International bank routing number
+          type: string
+        legalEntityIdentifier:
+          description: The legal entity identifier (LEI) for the beneficiary.  Aligns
+            with [ISO 17442](https://www.iso.org/standard/59771.html)
+          type: string
+      required:
+        - accountNumber
+        - country
+      type: object
+    BankingDirectDebit:
+      properties:
+        accountId:
+          description: A unique ID of the account adhering to the standards for ID
+            permanence.
+          type: string
+        authorisedEntity:
+          $ref: '#/components/schemas/BankingAuthorisedEntity'
+        lastDebitDateTime:
+          description: The date and time of the last debit executed under this authorisation
+          type: string
+        lastDebitAmount:
+          description: The amount of the last debit executed under this authorisation
+          type: string
+        adatree:
+          $ref: '#/components/schemas/Adatree'
+      required:
+        - accountId
+        - authorisedEntity
+      type: object
+    BankingAuthorisedEntity:
+      properties:
+        description:
+          description: Description of the authorised entity derived from previously
+            executed direct debits
+          type: string
+        financialInstitution:
+          description: Name of the financial institution through which the direct
+            debit will be executed. Is required unless the payment is made via a credit
+            card scheme
+          type: string
+        abn:
+          description: Australian Business Number for the authorised entity
+          type: string
+        acn:
+          description: Australian Company Number for the authorised entity
+          type: string
+        arbn:
+          description: Australian Registered Body Number for the authorised entity
+          type: string
+      type: object
+      x-conditional:
+        - financialInstitution
+    ResponseCommonCustomerList:
+      type: object
+      required:
+        - data
+        - links
+      properties:
+        data:
+          $ref: '#/components/schemas/ResponseCommonCustomerList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+      x-conditional:
+        - person
+        - organisation
+    ResponseCommonCustomerList_data:
+      type: object
+      required:
+        - customers
+      properties:
+        customers:
+          type: array
+          description: The list of common customers returned returned. If the filter results in an empty set then this array may have no records
+          items:
+            $ref: '#/components/schemas/CommonCustomer'
+    CommonCustomer:
+      type: object
+      required:
+        - customerUType
+        - adatree
+      properties:
+        customerUType:
+          type: string
+          description: The type of customer object that is present
+          example: person
+          enum:
+            - person
+            - organisation
+        person:
+          $ref: '#/components/schemas/CommonPersonDetail'
+        organisation:
+          $ref: '#/components/schemas/CommonOrganisationDetail'
+        adatree:
+          $ref: '#/components/schemas/Adatree'
+    CommonPerson:
+      type: object
+      required:
+        - lastName
+        - middleNames
+      properties:
+        lastUpdateTime:
+          type: string
+          example: "1997-01-12T15:43:00.121Z"
+          description: The date and time that this record was last updated by the customer.  If no update has occurred then this date should reflect the initial creation date for the data
+        firstName:
+          type: string
+          example: John
+          description: For people with single names this field need not be present.  The single name should be in the lastName field
+        lastName:
+          type: string
+          example: Doe
+          description: For people with single names the single name should be in this field
+        middleNames:
+          type: array
+          description: Field is mandatory but array may be empty
+          example: [ ]
+          items:
+            type: string
+        prefix:
+          type: string
+          example: Mr
+          description: Also known as title or salutation.  The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
+        suffix:
+          type: string
+          example: Jr
+          description: Used for a trailing suffix to the name (e.g. Jr)
+        occupationCode:
+          type: string
+          example: 233211
+          description: Value is a valid [ANZSCO](http://www.abs.gov.au/ANZSCO) Standard Occupation classification code. If the occupation code held by the data holder is not one of the supported [ANZSCO](http://www.abs.gov.au/ANZSCO) versions, then it must not be supplied.
+        occupationCodeVersion:
+          type: string
+          description: The applicable **[[ANZSCO]](#iref-ANZSCO)** release version of the occupation code provided. Mandatory if an ``occupationCode`` is supplied. If ``occupationCode`` is supplied but ``occupationCodeVersion`` is absent, default is ``ANZSCO_1220.0_2013_V1.2``
+          default: ANZSCO_1220.0_2013_V1.2
+          enum:
+            - ANZSCO_1220.0_2006_V1.0
+            - ANZSCO_1220.0_2006_V1.1
+            - ANZSCO_1220.0_2013_V1.2
+            - ANZSCO_1220.0_2013_V1.3
+    CommonPersonDetail:
+      allOf:
+        - $ref: '#/components/schemas/CommonPerson'
+        - type: object
+          required:
+            - emailAddresses
+            - phoneNumbers
+            - physicalAddresses
+          properties:
+            phoneNumbers:
+              type: array
+              description: Array is mandatory but may be empty if no phone numbers are held
+              items:
+                $ref: '#/components/schemas/CommonPhoneNumber'
+            emailAddresses:
+              type: array
+              description: May be empty
+              items:
+                $ref: '#/components/schemas/CommonEmailAddress'
+            physicalAddresses:
+              type: array
+              description: Must contain at least one address. One and only one address may have the purpose of REGISTERED. Zero or one, and no more than one, record may have the purpose of MAIL. If zero then the REGISTERED address is to be used for mail
+              items:
+                $ref: '#/components/schemas/CommonPhysicalAddressWithPurpose'
+    CommonOrganisation:
+      type: object
+      required:
+        - agentLastName
+        - agentRole
+        - businessName
+        - organisationType
+      properties:
+        lastUpdateTime:
+          type: string
+          example: "1997-01-12T15:43:00.121Z"
+          description: The date and time that this record was last updated by the customer. If no update has occurred then this date should reflect the initial creation date for the data
+        agentFirstName:
+          type: string
+          example: Jane
+          description: The first name of the individual providing access on behalf of the organisation. For people with single names this field need not be present.  The single name should be in the lastName field
+        agentLastName:
+          type: string
+          example: Doe
+          description: The last name of the individual providing access on behalf of the organisation. For people with single names the single name should be in this field
+        agentRole:
+          type: string
+          example: manager
+          description: The role of the individual identified as the agent who is providing authorisation.  Expected to be used for display. Default to Unspecified if the role is not known
+        businessName:
+          type: string
+          example: bumpty
+          description: Name of the organisation
+        legalName:
+          type: string
+          example: dumpty
+          description: Legal name, if different to the business name
+        shortName:
+          type: string
+          example: bdumpty
+          description: Short name used for communication, if different to the business name
+        abn:
+          type: string
+          example: 2342342342
+          description: Australian Business Number for the organisation
+        acn:
+          type: string
+          example: 13241234234
+          description: Australian Company Number for the organisation. Required only if an ACN is applicable for the organisation type
+        isACNCRegistered:
+          type: boolean
+          example: true
+          description: True if registered with the ACNC.  False if not. Absent or null if not confirmed.
+        industryCode:
+          type: string
+          example: MINING
+          description: A valid [ANZSIC](http://www.abs.gov.au/ANZSIC) code for the organisation. If the industry code held by the data holder is not one of the supported [ANZSIC](http://www.abs.gov.au/ANZSIC) versions, then it must not be supplied.
+        industryCodeVersion:
+          type: string
+          description: The applicable [ANZSIC](http://www.abs.gov.au/ANZSIC) release version of the industry code provided. Should only be supplied if ``industryCode`` is also supplied. If ``industryCode`` is supplied but ``industryCodeVersion`` is absent, default is ``ANZSIC_1292.0_2006_V2.0``
+          default: ANZSIC_1292.0_2006_V2.0
+          enum:
+            - ANZSIC_1292.0_2006_V1.0
+            - ANZSIC_1292.0_2006_V2.0
+        organisationType:
+          type: string
+          example: COMPANY
+          description: Legal organisation type
+          enum:
+            - COMPANY
+            - GOVERNMENT_ENTITY
+            - PARTNERSHIP
+            - SOLE_TRADER
+            - TRUST
+            - OTHER
+        registeredCountry:
+          type: string
+          description: Enumeration with values from [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country codes.  Assumed to be AUS if absent
+          example: AUS
+        establishmentDate:
+          type: string
+          description: The date the organisation described was established
+          example: "2017-12-31"
+    CommonOrganisationDetail:
+      allOf:
+        - $ref: '#/components/schemas/CommonOrganisation'
+        - type: object
+          required:
+            - physicalAddresses
+          properties:
+            physicalAddresses:
+              type: array
+              description: Must contain at least one address. One and only one address may have the purpose of REGISTERED. Zero or one, and no more than one, record may have the purpose of MAIL. If zero then the REGISTERED address is to be used for mail
+              items:
+                $ref: '#/components/schemas/CommonPhysicalAddressWithPurpose'
+    CommonPhoneNumber:
+      type: object
+      required:
+        - fullNumber
+        - number
+        - purpose
+      properties:
+        isPreferred:
+          type: boolean
+          description: May be true for one and only one entry to indicate the preferred phone number. Assumed to be 'false' if not present
+          example: true
+        purpose:
+          type: string
+          description: The purpose of the number as specified by the customer
+          example: HOME
+          enum:
+            - MOBILE
+            - HOME
+            - INTERNATIONAL
+            - WORK
+            - OTHER
+            - UNSPECIFIED
+        countryCode:
+          type: string
+          description: If absent, assumed to be Australia (+61). The + should be included
+          example: +61
+        areaCode:
+          type: string
+          description: Required for non Mobile Phones, if field is present and refers to Australian code - the leading 0 should be omitted.
+          example: ""
+        number:
+          type: string
+          description: The actual phone number, with leading zeros as appropriate
+          example: 400000000
+        extension:
+          type: string
+          example: ""
+          description: An extension number (if applicable)
+        fullNumber:
+          type: string
+          description: Fully formatted phone number with country code, area code, number and extension incorporated. Formatted according to section 5.1.4. of [RFC 3966](https://www.ietf.org/rfc/rfc3966.txt)
+          example: +61400000000
+      x-conditional:
+        - areaCode
+    CommonEmailAddress:
+      type: object
+      required:
+        - address
+        - purpose
+      properties:
+        isPreferred:
+          type: boolean
+          description: May be true for one and only one email record in the collection. Denotes the default email address
+          example: true
+        purpose:
+          type: string
+          description: The purpose for the email, as specified by the customer (Enumeration)
+          example: WORK
+          enum:
+            - WORK
+            - HOME
+            - OTHER
+            - UNSPECIFIED
+        address:
+          type: string
+          example: 1 Pitt ST SYDNEY NSW 2000
+          description: A correctly formatted email address, as defined by the addr_spec format in [RFC 5322](https://www.ietf.org/rfc/rfc5322.txt)
+    CommonPhysicalAddressWithPurpose:
+      allOf:
+        - $ref: '#/components/schemas/CommonPhysicalAddress'
+        - type: object
+          required:
+            - purpose
+          properties:
+            purpose:
+              type: string
+              description: Enumeration of values indicating the purpose of the physical address
+              example: WORK
+              enum:
+                - MAIL
+                - PHYSICAL
+                - REGISTERED
+                - WORK
+                - OTHER
+    #-------------------------------
+    # Energy Schema Definitions
+    #-------------------------------
+    EnergyServicePointList:
+      properties:
+        data:
+          $ref: '#/components/schemas/EnergyServicePointList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+      required:
+        - data
+        - links
+        - meta
+      type: object
+    EnergyUsageList:
+      properties:
+        data:
+          $ref: '#/components/schemas/EnergyUsageList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+      required:
+        - data
+        - links
+        - meta
+      type: object
+    EnergyInvoiceList:
+      properties:
+        data:
+          $ref: '#/components/schemas/EnergyInvoiceList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+      required:
+        - data
+        - links
+        - meta
+      type: object
+    EnergyBillingList:
+      properties:
+        data:
+          $ref: '#/components/schemas/EnergyBillingList_data'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
+      required:
+        - data
+        - links
+        - meta
+      type: object
+    EnergyPlanContract:
+      properties:
+        additionalFeeInformation:
+          description: Free text field containing additional information of the fees
+            for this contract
+          type: string
+        pricingModel:
+          description: The pricing model for the contract.  Contracts for gas must
+            use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE**
+            - all energy usage is charged at a single unit rate no matter when it
+            is consumed. Multiple unit rates may exist that correspond to varying
+            volumes of usage i.e. a block or step tariff (first 50kWh @ X cents,
+            next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above,
+            but with an additional, separate unit rate charged for all energy usage
+            from a controlled load i.e. separately metered appliance like hot water
+            service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged
+            at unit rates that vary dependent on time of day and day of week that
+            the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but
+            with an additional, separate unit rate charged for all energy usage from
+            a controlled load i.e. separately metered appliance like hot water service,
+            pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit
+            rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD**
+            - as above, but with an additional, separate unit rate charged for all
+            energy usage from a controlled load i.e. separately metered appliance
+            like hot water service, pool pump etc.</li><li>**QUOTA** - all energy
+            usage is charged at a single fixed rate, up to a specified usage quota/allowance.
+            All excess usage beyond the allowance is then charged at a single unit
+            rate (may not be the best way to explain it but it is essentially a subscription
+            or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
+          enum:
+            - SINGLE_RATE
+            - SINGLE_RATE_CONT_LOAD
+            - TIME_OF_USE
+            - TIME_OF_USE_CONT_LOAD
+            - FLEXIBLE
+            - FLEXIBLE_CONT_LOAD
+            - QUOTA
+          type: string
+        timeZone:
+          description: Required if pricingModel is set to TIME_OF_USE.  Defines the
+            time zone to use for calculation of the time of use thresholds. Defaults
+            to AEST if absent
+          enum:
+            - LOCAL
+            - AEST
+          type: string
+        isFixed:
+          description: Flag indicating whether prices are fixed or variable
+          type: boolean
+        variation:
+          description: Free text description of price variation policy and conditions
+            for the contract.  Mandatory if `isFixed` is false
+          type: string
+        onExpiryDescription:
+          description: Free text field that describes what will occur on or prior
+            to expiry of the fixed contract term or benefit period
+          type: string
+        paymentOption:
+          description: Payment options for this contract
+          items:
+            enum:
+              - PAPER_BILL
+              - CREDIT_CARD
+              - DIRECT_DEBIT
+              - BPAY
+              - OTHER
+            type: string
+          type: array
+        intrinsicGreenPower:
+          $ref: '#/components/schemas/EnergyPlanContract_intrinsicGreenPower'
+        controlledLoad:
+          description: Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD
+            or FLEXIBLE_CONT_LOAD
+          items:
+            properties:
+              displayName:
+                description: A display name for the controlled load
+                type: string
+              rateBlockUType:
+                description: 'Specifies the type of controlloed load rate '
+                enum:
+                  - singleRate
+                  - timeOfUseRates
+                type: string
+              startDate:
+                description: Optional start date of the application of the controlled
+                  load rate
+                type: string
+              endDate:
+                description: Optional end date of the application of the controlled
+                  load rate
+                type: string
+              singleRate:
+                description: Object representing a single controlled load rate.  Required
+                  if rateBlockUType is singleRate
+                properties:
+                  displayName:
+                    description: Display name of the controlled load rate
+                    type: string
+                  description:
+                    description: Description of the controlled load rate
+                    type: string
+                  dailySupplyCharge:
+                    description: The daily supply charge (exclusive of GST) for this
+                      controlled load tier
+                    type: string
+                  rates:
+                    description: Array of controlled load rates in order of usage
+                      volume
+                    items:
+                      properties:
+                        unitPrice:
+                          description: Unit price of usage per  measure unit (exclusive
+                            of GST)
+                          type: string
+                        measureUnit:
+                          description: The measurement unit of rate. Assumed to be
+                            KWH if absent
+                          enum:
+                            - KWH
+                            - KVA
+                            - KVAR
+                            - KVARH
+                            - KW
+                            - DAYS
+                            - METER
+                            - MONTH
+                          type: string
+                        volume:
+                          description: Volume in kWh that this rate applies to.  Only
+                            applicable for stepped rates where different rates apply
+                            for different volumes of usage in a period
+                          type: number
+                      required:
+                        - unitPrice
+                      type: object
+                    type: array
+                required:
+                  - displayName
+                  - rates
+                type: object
+              timeOfUseRates:
+                description: Array of objects representing time of use rates.  Required
+                  if rateBlockUType is timeOfUseRates
+                items:
+                  properties:
+                    displayName:
+                      description: Display name of the controlled load rate
+                      type: string
+                    description:
+                      description: Description of the controlled load rate
+                      type: string
+                    dailySupplyCharge:
+                      description: The daily supply charge (exclusive of GST) for
+                        this controlled load tier
+                      type: string
+                    rates:
+                      description: Array of controlled load rates in order of usage
+                        volume
+                      items:
+                        properties:
+                          unitPrice:
+                            description: Unit price of usage per  measure unit (exclusive
+                              of GST)
+                            type: string
+                          measureUnit:
+                            description: The measurement unit of rate. Assumed to
+                              be KWH if absent
+                            enum:
+                              - KWH
+                              - KVA
+                              - KVAR
+                              - KVARH
+                              - KW
+                              - DAYS
+                              - METER
+                              - MONTH
+                            type: string
+                          volume:
+                            description: Volume in kWh that this rate applies to.  Only
+                              applicable for stepped rates where different rates
+                              apply for different volumes of usage in a period
+                            type: number
+                        required:
+                          - unitPrice
+                        type: object
+                      type: array
+                    timeOfUse:
+                      description: Array of times of use.
+                      items:
+                        properties:
+                          days:
+                            description: The days that the rate applies to
+                            items:
+                              enum:
+                                - SUN
+                                - MON
+                                - TUE
+                                - WED
+                                - THU
+                                - FRI
+                                - SAT
+                                - PUBLIC_HOLIDAYS
+                              type: string
+                            type: array
+                          startTime:
+                            description: The beginning of the time period per day
+                              for which the controlled load rate applies. Required
+                              if endTime provided
+                            type: string
+                          endTime:
+                            description: The end of the time period per day for which
+                              the controlled load rate applies. Required if startTime
+                              provided
+                            type: string
+                          additionalInfo:
+                            description: Display text providing more information on
+                              the contrlled load, for e.g. controlled load availability
+                              if specific day/time is not known. Required if startTime
+                              and endTime absent or if additionalInfoUri provided
+                            type: string
+                          additionalInfoUri:
+                            description: Optional link to additional information regarding
+                              the controlled load
+                            type: string
+                        type: object
+                        x-conditional:
+                          - startTime
+                          - endTime
+                          - additionalInfo
+                      type: array
+                    type:
+                      description: The type of usage that the rate applies to
+                      enum:
+                        - PEAK
+                        - OFF_PEAK
+                        - SHOULDER
+                        - SOLAR_SPONGE
+                      type: string
+                  required:
+                    - displayName
+                    - rates
+                    - timeOfUse
+                    - type
+                  type: object
+                type: array
+            required:
+              - displayName
+              - rateBlockUType
+            type: object
+            x-conditional:
+              - singleRate
+              - timeOfUseRates
+          type: array
+        incentives:
+          description: Optional list of incentives available for the contract
+          items:
+            properties:
+              displayName:
+                description: The display name of the incentive
+                type: string
+              description:
+                description: The description of the incentive
+                type: string
+              category:
+                description: The type of the incentive
+                enum:
+                  - GIFT
+                  - ACCOUNT_CREDIT
+                  - OTHER
+                type: string
+              eligibility:
+                description: A display message outlining an eligibility criteria that
+                  may apply
+                type: string
+            required:
+              - category
+              - description
+              - displayName
+            type: object
+          type: array
+        discounts:
+          description: Optional list of discounts available for the contract
+          items:
+            properties:
+              displayName:
+                description: The display name of the discount
+                type: string
+              description:
+                description: The description of the discount
+                type: string
+              type:
+                description: The type of the discount
+                enum:
+                  - CONDITIONAL
+                  - GUARANTEED
+                  - OTHER
+                type: string
+              category:
+                description: The type of the discount.  Mandatory if the discount
+                  type is CONDITIONAL
+                enum:
+                  - PAY_ON_TIME
+                  - DIRECT_DEBIT
+                  - GUARANTEED_DISCOUNT
+                  - OTHER
+                type: string
+              endDate:
+                description: Optional end date for the discount after which the discount
+                  is no longer available
+                type: string
+              methodUType:
+                description: The method of calculation of the discount
+                enum:
+                  - percentOfBill
+                  - percentOfUse
+                  - fixedAmount
+                  - percentOverThreshold
+                type: string
+              percentOfBill:
+                description: Required if methodUType is percentOfBill
+                properties:
+                  rate:
+                    description: The rate of the discount applied to the bill amount
+                    type: string
+                required:
+                  - rate
+                type: object
+              percentOfUse:
+                description: Required if methodUType is percentOfUse
+                properties:
+                  rate:
+                    description: The rate of the discount applied to the usageamount
+                    type: string
+                required:
+                  - rate
+                type: object
+              fixedAmount:
+                description: Required if methodUType is fixedAmount
+                properties:
+                  amount:
+                    description: The amount of the discount
+                    type: string
+                required:
+                  - amount
+                type: object
+              percentOverThreshold:
+                description: Required if methodUType is percentOverThreshold
+                properties:
+                  rate:
+                    description: The rate of the discount over the usage amount
+                    type: string
+                  usageAmount:
+                    description: The usage amount threshold above which the discount
+                      applies
+                    type: string
+                required:
+                  - rate
+                  - usageAmount
+                type: object
+            required:
+              - displayName
+              - methodUType
+              - type
+            type: object
+          type: array
+        greenPowerCharges:
+          description: Optional list of charges applicable to green power
+          items:
+            properties:
+              displayName:
+                description: The display name of the charge
+                type: string
+              description:
+                description: The description of the charge
+                type: string
+              scheme:
+                description: The applicable green power scheme
+                enum:
+                  - GREENPOWER
+                  - OTHER
+                type: string
+              type:
+                description: The type of charge
+                enum:
+                  - FIXED_PER_DAY
+                  - FIXED_PER_WEEK
+                  - FIXED_PER_MONTH
+                  - FIXED_PER_UNIT
+                  - PERCENT_OF_USE
+                  - PERCENT_OF_BILL
+                type: string
+              tiers:
+                description: Array of charge tiers based on the percentage of green
+                  power used for the period implied by the type.  Array is in order
+                  of increasing percentage of green power
+                items:
+                  properties:
+                    percentGreen:
+                      description: The upper percentage of green power used applicable
+                        for this tier
+                      type: string
+                    rate:
+                      description: The rate of the charge if the type implies the
+                        application of a rate
+                      type: string
+                    amount:
+                      description: The amount of the charge if the type implies the
+                        application of a fixed amount
+                      type: string
+                  required:
+                    - percentGreen
+                  type: object
+                  x-conditional:
+                    - rate
+                    - amount
+                type: array
+            required:
+              - displayName
+              - scheme
+              - tiers
+              - type
+            type: object
+          type: array
+        eligibility:
+          description: Eligibility restrictions or requirements
+          items:
+            properties:
+              type:
+                description: The type of the eligibility restriction.<br/>The CONTINGENT_PLAN
+                  value indicates that the plan is contingent on the customer taking
+                  up an alternate fuel plan from the same retailer (for instance,
+                  if the fuelType is ELECTRICITY then a GAS plan from the same retailer
+                  must be taken up)
+                enum:
+                  - EXISTING_CUST
+                  - EXISTING_POOL
+                  - EXISTING_SOLAR
+                  - EXISTING_BATTERY
+                  - EXISTING_SMART_METER
+                  - EXISTING_BASIC_METER
+                  - SENIOR_CARD
+                  - SMALL_BUSINESS
+                  - NO_SOLAR_FIT
+                  - NEW_CUSTOMER
+                  - ONLINE_ONLY
+                  - REQ_EQUIP_SUPPLIER
+                  - THIRD_PARTY_ONLY
+                  - SPORT_CLUB_MEMBER
+                  - ORG_MEMBER
+                  - SPECIFIC_LOCATION
+                  - MINIMUM_USAGE
+                  - LOYALTY_MEMBER
+                  - GROUP_BUY_MEMBER
+                  - CONTINGENT_PLAN
+                  - OTHER
+                type: string
+              information:
+                description: Information of the eligibility restriction specific to
+                  the type of the restriction
+                type: string
+              description:
+                description: A description of the eligibility restriction
+                type: string
+            required:
+              - information
+              - type
+            type: object
+          type: array
+        fees:
+          description: An array of fees applicable to the plan
+          items:
+            properties:
+              type:
+                description: The type of the fee
+                enum:
+                  - EXIT
+                  - ESTABLISHMENT
+                  - LATE_PAYMENT
+                  - DISCONNECTION
+                  - DISCONNECT_MOVE_OUT
+                  - DISCONNECT_NON_PAY
+                  - RECONNECTION
+                  - CONNECTION
+                  - PAYMENT_PROCESSING
+                  - CC_PROCESSING
+                  - CHEQUE_DISHONOUR
+                  - DD_DISHONOUR
+                  - MEMBERSHIP
+                  - CONTRIBUTION
+                  - PAPER_BILL
+                  - OTHER
+                type: string
+              term:
+                description: The term of the fee
+                enum:
+                  - FIXED
+                  - 1_YEAR
+                  - 2_YEAR
+                  - 3_YEAR
+                  - 4_YEAR
+                  - 5_YEAR
+                  - PERCENT_OF_BILL
+                  - ANNUAL
+                  - DAILY
+                  - WEEKLY
+                  - MONTHLY
+                  - BIANNUAL
+                  - VARIABLE
+                type: string
+              amount:
+                description: The fee amount. Required if term is not PERCENT_OF_BILL
+                type: string
+              rate:
+                description: The fee rate. Required if term is PERCENT_OF_BILL
+                type: string
+              description:
+                description: A description of the fee
+                type: string
+            required:
+              - term
+              - type
+            type: object
+            x-conditional:
+              - amount
+              - rate
+          type: array
+        solarFeedInTariff:
+          description: Array of feed in tariffs for solar power
+          items:
+            properties:
+              displayName:
+                description: The name of the tariff
+                type: string
+              description:
+                description: A description of the tariff
+                type: string
+              startDate:
+                description: The start date of the application of the feed in tariff
+                type: string
+                x-cds-type: DateString
+              endDate:
+                description: The end date of the application of the feed in tariff
+                type: string
+                x-cds-type: DateString
+              scheme:
+                description: The applicable scheme
+                enum:
+                  - PREMIUM
+                  - CURRENT
+                  - VARIABLE
+                  - OTHER
+                type: string
+              payerType:
+                description: The type of the payer
+                enum:
+                  - GOVERNMENT
+                  - RETAILER
+                type: string
+              tariffUType:
+                description: The type of the payer
+                enum:
+                  - singleTariff
+                  - timeVaryingTariffs
+                type: string
+              singleTariff:
+                description: Represents a constant tariff.  Mandatory if tariffUType
+                  is set to singleTariff
+                properties:
+                  amount:
+                    description: The tariff amount. This will be the tariff representation returned by data holders support EnergyAccountDetailV2.
+                    type: string
+                  rates:
+                    description: Array of feed in rates. This will be the tariff representation returned by data holders support EnergyAccountDetailV3.
+                    items:
+                      properties:
+                        unitPrice:
+                          description: Unit price of usage per measure unit (exclusive
+                            of GST)
+                          type: string
+                          x-cds-type: AmountString
+                        measureUnit:
+                          description: The measurement unit of rate. Assumed to be
+                            KWH if absent
+                          enum:
+                            - KWH
+                            - KVA
+                            - KVAR
+                            - KVARH
+                            - KW
+                            - DAYS
+                            - METER
+                            - MONTH
+                          type: string
+                        volume:
+                          description: Volume that this rate applies to. Only applicable
+                            for ‘stepped’ rates where different rates apply for different
+                            volumes of usage in a period
+                          type: number
+                      required:
+                        - unitPrice
+                      type: object
+                    type: array
+                  period:
+                    description: Usage period for which the block rate applies. Defaults to P1Y if absent.
+                      This will be the tariff representation returned by data holders that support EnergyAccountDetailV4.
+                    type: string
+                type: object
+              timeVaryingTariffs:
+                description: Represents a tariff based on time.  Mandatory if tariffUType
+                  is set to timeVaryingTariffs
+                properties:
+                  type:
+                    description: The type of the charging time period. If absent applies
+                      to all periods
+                    enum:
+                      - PEAK
+                      - OFF_PEAK
+                      - SHOULDER
+                    type: string
+                  displayName:
+                    description: Display name of the tariff
+                    type: string
+                  amount:
+                    description: The tariff amount
+                    type: string
+                  rates:
+                    description: Array of feed in rates. This will be the tariff representation returned by data holders support EnergyAccountDetailV3.
+                    items:
+                      properties:
+                        unitPrice:
+                          description: Unit price of usage per measure unit (exclusive
+                            of GST)
+                          type: string
+                          x-cds-type: AmountString
+                        measureUnit:
+                          description: The measurement unit of rate. Assumed to be
+                            KWH if absent
+                          enum:
+                            - KWH
+                            - KVA
+                            - KVAR
+                            - KVARH
+                            - KW
+                            - DAYS
+                            - METER
+                            - MONTH
+                          type: string
+                        volume:
+                          description: Volume that this rate applies to. Only applicable
+                            for ‘stepped’ rates where different rates apply for different
+                            volumes of usage in a period
+                          type: number
+                      required:
+                        - unitPrice
+                      type: object
+                    type: array
+                  timeVariations:
+                    description: Array of time periods for which this tariff is applicable
+                    items:
+                      properties:
+                        days:
+                          description: The days that the tariff applies to. At least
+                            one entry required
+                          items:
+                            enum:
+                              - SUN
+                              - MON
+                              - TUE
+                              - WED
+                              - THU
+                              - FRI
+                              - SAT
+                              - PUBLIC_HOLIDAYS
+                            type: string
+                          type: array
+                        startTime:
+                          description: The beginning of the time period per day for
+                            which the tariff applies.  If absent assumes start of
+                            day (ie. midnight)
+                          type: string
+                        endTime:
+                          description: The end of the time period per day for which
+                            the tariff applies.  If absent assumes end of day (ie.
+                            one second before midnight)
+                          type: string
+                      required:
+                        - days
+                      type: object
+                    type: array
+                  period:
+                    description: Usage period for which the block rate applies. Defaults to P1Y if absent.
+                      This will be the tariff representation returned by data holders support EnergyAccountDetailV4.
+                    type: string
+                required:
+                  - displayName
+                  - timeVariations
+                type: object
+            required:
+              - displayName
+              - payerType
+              - scheme
+              - tariffUType
+            type: object
+            x-conditional:
+              - singleTariff
+              - timeVaryingTariffs
+          type: array
+        tariffPeriod:
+          description: Array of tariff periods
+          items:
+            properties:
+              type:
+                description: Type of charge. Assumed to be other if absent
+                enum:
+                  - ENVIRONMENTAL
+                  - REGULATED
+                  - NETWORK
+                  - METERING
+                  - RETAIL_SERVICE
+                  - RCTI
+                  - OTHER
+                type: string
+              displayName:
+                description: The name of the tariff period
+                type: string
+              startDate:
+                description: The start date of the tariff period in a calendar year.  Formatted
+                  in mm-dd format
+                type: string
+              endDate:
+                description: The end date of the tariff period in a calendar year.  Formatted
+                  in mm-dd format
+                type: string
+              dailySupplyChargeType:
+                description: Specifies if daily supply charge is single or banded.
+                  This is for EnergyAccountDetailV4.
+                enum:
+                  - SINGLE
+                  - BAND
+                type: string
+              dailySupplyCharge:
+                description: The amount of access charge for the tariff period, in
+                  dollars per day exclusive of GST. Mandatory if dailySupplyChargeType is SINGLE.
+                  This is for EnergyAccountDetailV4.
+                type: string
+              bandedDailySupplyCharges:
+                description: Array representing banded daily supply charge rates.
+                  Mandatory if dailySupplyChargeType is BAND. This is for EnergyAccountDetailV4.
+                items:
+                  properties:
+                    unitPrice:
+                      description: The amount of daily supply charge for the band, in dollars per day exclusive of GST.
+                      type: string
+                    measureUnit:
+                      description: The measurement unit of rate. Assumed to be DAYS if absent
+                      enum:
+                        - KWH
+                        - KVA
+                        - KVAR
+                        - KVARH
+                        - KW
+                        - DAYS
+                        - METER
+                        - MONTH
+                      type: string
+                    volume:
+                      description: Volume the charge applies to
+                      type: number
+                  required:
+                    - unitPrice
+                  type: object
+                type: array
+              dailySupplyCharges:
+                description: The amount of access charge for the tariff period, in
+                  dollars per day exclusive of GST.
+                type: string
+              timeZone:
+                description: Specifies the charge specific time zone for calculation
+                  of the time of use thresholds. If absent, timezone value in EnergyPlanContract
+                  is assumed.
+                enum:
+                  - LOCAL
+                  - AEST
+                type: string
+              rateBlockUType:
+                description: Specifies the type of rate applicable to this tariff
+                  period
+                enum:
+                  - singleRate
+                  - timeOfUseRates
+                  - demandCharges
+                type: string
+              singleRate:
+                description: Object representing a single rate.  Required if rateBlockUType
+                  is singleRate
+                properties:
+                  displayName:
+                    description: Display name of the rate
+                    type: string
+                  description:
+                    description: Description of the rate
+                    type: string
+                  generalUnitPrice:
+                    description: The block rate (unit price) for any usage above the
+                      included fixed usage, in dollars per kWh inclusive of GST.  Only
+                      required if pricingModel field is QUOTA
+                    type: string
+                  rates:
+                    description: Array of controlled load rates in order of usage
+                      volume
+                    items:
+                      properties:
+                        unitPrice:
+                          description: Unit price of usage per measure unit (exclusive
+                            of GST)
+                          type: string
+                        measureUnit:
+                          description: The measurement unit of rate. Assumed to be
+                            KWH if absent
+                          enum:
+                            - KWH
+                            - KVA
+                            - KVAR
+                            - KVARH
+                            - KW
+                            - DAYS
+                            - METER
+                            - MONTH
+                          type: string
+                        volume:
+                          description: Volume in kWh that this rate applies to.  Only
+                            applicable for stepped rates where different rates apply
+                            for different volumes of usage in a period
+                          type: number
+                      required:
+                        - unitPrice
+                      type: object
+                    type: array
+                  period:
+                    description: Usage period for which the block rate applies. Formatted
+                      according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)
+                      (excludes recurrence syntax)
+                    type: string
+                required:
+                  - displayName
+                  - rates
+                type: object
+                x-conditional:
+                  - generalUnitPrice
+              timeOfUseRates:
+                description: Array of objects representing time of use rates.  Required
+                  if rateBlockUType is timeOfUseRates
+                items:
+                  properties:
+                    displayName:
+                      description: Display name of the rate
+                      type: string
+                    description:
+                      description: Description of the rate
+                      type: string
+                    rates:
+                      description: Array of controlled load rates in order of usage
+                        volume
+                      items:
+                        properties:
+                          unitPrice:
+                            description: Unit price of usage per  measure unit (exclusive
+                              of GST)
+                            type: string
+                          measureUnit:
+                            description: The measurement unit of rate. Assumed to
+                              be KWH if absent
+                            enum:
+                              - KWH
+                              - KVA
+                              - KVAR
+                              - KVARH
+                              - KW
+                              - DAYS
+                              - METER
+                              - MONTH
+                            type: string
+                          volume:
+                            description: Volume in kWh that this rate applies to.  Only
+                              applicable for stepped rates where different rates
+                              apply for different volumes of usage in a period
+                            type: number
+                        required:
+                          - unitPrice
+                        type: object
+                      type: array
+                    period:
+                      description: Usage period for which the block rate applies. Defaults to P1Y if absent.
+                        This will be the tariff representation returned by data holders support EnergyAccountDetailV4.
+                      type: string
+                    timeOfUse:
+                      description: Array of times of use
+                      items:
+                        properties:
+                          days:
+                            description: The days that the rate applies to
+                            items:
+                              enum:
+                                - SUN
+                                - MON
+                                - TUE
+                                - WED
+                                - THU
+                                - FRI
+                                - SAT
+                                - PUBLIC_HOLIDAYS
+                              type: string
+                            type: array
+                          startTime:
+                            description: Start of the period
+                            type: string
+                          endTime:
+                            description: End of the period
+                            type: string
+                        required:
+                          - days
+                          - endTime
+                          - startTime
+                        type: object
+                      type: array
+                    type:
+                      description: The type of usage that the rate applies to
+                      enum:
+                        - PEAK
+                        - OFF_PEAK
+                        - SHOULDER
+                        - SHOULDER1
+                        - SHOULDER2
+                      type: string
+                  required:
+                    - displayName
+                    - rates
+                    - timeOfUse
+                    - type
+                  type: object
+                type: array
+              demandCharges:
+                description: Array of demand charges.  Required if rateBlockUType
+                  is demandCharges
+                items:
+                  properties:
+                    displayName:
+                      description: Display name of the charge
+                      type: string
+                    description:
+                      description: Description of the charge
+                      type: string
+                    amount:
+                      description: The charge amount per  measure unit exclusive of
+                        GST
+                      type: string
+                    measureUnit:
+                      description: The measurement unit of charge amount. Assumed
+                        to be KWH if absent
+                      enum:
+                        - KWH
+                        - KVA
+                        - KVAR
+                        - KVARH
+                        - KW
+                        - DAYS
+                        - METER
+                        - MONTH
+                      type: string
+                    startTime:
+                      description: Start of the period
+                      type: string
+                    endTime:
+                      description: End of the period
+                      type: string
+                    days:
+                      description: The days that the demand tariff applies to
+                      items:
+                        enum:
+                          - SUN
+                          - MON
+                          - TUE
+                          - WED
+                          - THU
+                          - FRI
+                          - SAT
+                          - PUBLIC_HOLIDAYS
+                        type: string
+                      type: array
+                    minDemand:
+                      description: Minimum demand for this demand tariff in kW.  If
+                        absent then 0 is assumed
+                      type: string
+                    maxDemand:
+                      description: Maximum demand for this demand tariff in kW.  If
+                        present, must be higher than the value of the minDemand field
+                      type: string
+                    measurementPeriod:
+                      description: Application period for the demand tariff
+                      enum:
+                        - DAY
+                        - MONTH
+                        - TARIFF_PERIOD
+                      type: string
+                    chargePeriod:
+                      description: Charge period for the demand tariff
+                      enum:
+                        - DAY
+                        - MONTH
+                        - TARIFF_PERIOD
+                      type: string
+                  required:
+                    - amount
+                    - chargePeriod
+                    - displayName
+                    - endTime
+                    - measurementPeriod
+                    - startTime
+                  type: object
+                type: array
+            required:
+              - displayName
+              - endDate
+              - rateBlockUType
+              - startDate
+            type: object
+            x-conditional:
+              - singleRate
+              - timeOfUseRates
+              - demandCharges
+              - dailySupplyCharge
+              - bandedDailySupplyCharges
+          type: array
+      required:
+        - isFixed
+        - paymentOption
+        - pricingModel
+        - tariffPeriod
+      type: object
+      x-conditional:
+        - timeZone
+        - variation
+        - controlledLoad
+    EnergyPlanContractV2:
+      allOf:
+        - $ref: '#/components/schemas/EnergyPlanContract'
+        - type: object
+          properties:
+            solarFeedInTariff:
+              type: array
+              description: "Array of solar feed-in tariffs (v2 schema: timeVaryingTariffs is an array)"
+              items:
+                $ref: '#/components/schemas/SolarFeedInTariffV2'
+    SolarFeedInTariffV2:
+      type: object
+      properties:
+        displayName:
+          description: The name of the tariff
+          type: string
+        description:
+          description: A description of the tariff
+          type: string
+        startDate:
+          description: The start date of the application of the feed in tariff
+          type: string
+        endDate:
+          description: The end date of the application of the feed in tariff
+          type: string
+        scheme:
+          description: The applicable scheme
+          enum:
+            - PREMIUM
+            - CURRENT
+            - VARIABLE
+            - OTHER
+          type: string
+        payerType:
+          description: The type of the payer
+          enum:
+            - GOVERNMENT
+            - RETAILER
+          type: string
+        tariffUType:
+          description: The type of the payer
+          enum:
+            - singleTariff
+            - timeVaryingTariffs
+          type: string
+        singleTariff:
+          description: Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
+          type: object
+          properties:
+            amount:
+              description: The tariff amount. This will be the tariff representation returned by data holders support EnergyAccountDetailV2.
+              type: string
+            rates:
+              description: Array of feed in rates. This will be the tariff representation returned by data holders support EnergyAccountDetailV3.
+              type: array
+              items:
+                type: object
+                properties:
+                  unitPrice:
+                    description: Unit price of usage per measure unit (exclusive of GST)
+                    type: string
+                  measureUnit:
+                    description: The measurement unit of rate. Assumed to be KWH if absent
+                    enum:
+                      - KWH
+                      - KVA
+                      - KVAR
+                      - KVARH
+                      - KW
+                      - DAYS
+                      - METER
+                      - MONTH
+                    type: string
+                  volume:
+                    description: Volume that this rate applies to. Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+                    type: number
+                required:
+                  - unitPrice
+            period:
+              description: Usage period for which the block rate applies. Defaults to P1Y if absent. This will be the tariff representation returned by data holders that support EnergyAccountDetailV4.
+              type: string
+        timeVaryingTariffs:
+          description: "v2: Represents a tariff based on time. Mandatory if tariffUType is set to timeVaryingTariffs. NOTE: v2 makes this an array."
+          type: array
+          items:
+            $ref: '#/components/schemas/EnergyPlanContractTimeVaryingTariffV2'
+      required:
+        - displayName
+        - payerType
+        - scheme
+        - tariffUType
+    EnergyPlanContractTimeVaryingTariffV2:
+      type: object
+      properties:
+        type:
+          description: The type of the charging time period. If absent applies
+            to all periods
+          enum:
+            - PEAK
+            - OFF_PEAK
+            - SHOULDER
+          type: string
+        displayName:
+          description: Display name of the tariff
+          type: string
+        amount:
+          description: The tariff amount
+          type: string
+        rates:
+          description: Array of feed in rates. This will be the tariff representation returned by data holders support EnergyAccountDetailV3.
+          items:
+            properties:
+              unitPrice:
+                description: Unit price of usage per measure unit (exclusive
+                  of GST)
+                type: string
+              measureUnit:
+                description: The measurement unit of rate. Assumed to be
+                  KWH if absent
+                enum:
+                  - KWH
+                  - KVA
+                  - KVAR
+                  - KVARH
+                  - KW
+                  - DAYS
+                  - METER
+                  - MONTH
+                type: string
+              volume:
+                description: Volume that this rate applies to. Only applicable
+                  for ‘stepped’ rates where different rates apply for different
+                  volumes of usage in a period
+                type: number
+            required:
+              - unitPrice
+            type: object
+          type: array
+        timeVariations:
+          description: Array of time periods for which this tariff is applicable
+          items:
+            properties:
+              days:
+                description: The days that the tariff applies to. At least
+                  one entry required
+                items:
+                  enum:
+                    - SUN
+                    - MON
+                    - TUE
+                    - WED
+                    - THU
+                    - FRI
+                    - SAT
+                    - PUBLIC_HOLIDAYS
+                  type: string
+                type: array
+              startTime:
+                description: The beginning of the time period per day for
+                  which the tariff applies. If absent assumes start of
+                  day (ie. midnight)
+                type: string
+              endTime:
+                description: The end of the time period per day for which
+                  the tariff applies. If absent assumes end of day (ie.
+                  one second before midnight)
+                type: string
+            required:
+              - days
+            type: object
+          type: array
+        period:
+          description: Usage period for which the block rate applies. Defaults to P1Y if absent.
+            This will be the tariff representation returned by data holders support EnergyAccountDetailV4.
+          type: string
+      required: [displayName, timeVariations]
+    EnergyServicePointDetail:
+      type: object
+      properties:
+        servicePointId:
+          description: The tokenised ID of the service point for use in the CDR APIs.  Created
+            according to the CDR rules for ID permanence
+          type: string
+        nationalMeteringId:
+          description: The independent ID of the service point, known in the industry
+            as the NMI
+          type: string
+        servicePointClassification:
+          description: The classification of the service point as defined in MSATS
+            procedures
+          enum:
+            - EXTERNAL_PROFILE
+            - GENERATOR
+            - LARGE
+            - SMALL
+            - WHOLESALE
+            - NON_CONTEST_UNMETERED_LOAD
+            - NON_REGISTERED_EMBEDDED_GENERATOR
+            - DISTRIBUTION_WHOLESALE
+          type: string
+        servicePointStatus:
+          description: 'Code used to indicate the status of the service point. Note
+            the details for the enumeration values below:<ul><li>**ACTIVE** - An active,
+            energised, service point</li><li>**DE_ENERGISED** - The service point
+            exists but is deenergised</li><li>**EXTINCT** - The service point has
+            been permanently decommissioned</li><li>**GREENFIELD** - Applies to a
+            service point that has never been energised</li><li>**OFF_MARKET** - Applies
+            when the service point is no longer settled in the NEM</li></ul> '
+          enum:
+            - ACTIVE
+            - DE_ENERGISED
+            - EXTINCT
+            - GREENFIELD
+            - OFF_MARKET
+          type: string
+        jurisdictionCode:
+          description: Jurisdiction code to which the service point belongs.This code
+            defines the jurisdictional rules which apply to the service point. Note
+            the details of enumeration values below:<ul><li>**ALL** - All Jurisdictions</li><li>**ACT**
+            - Australian Capital Territory</li><li>**NEM** - National Electricity
+            Market</li><li>**NSW** - New South Wales</li><li>**QLD** - Queensland</li><li>**SA**
+            - South Australia</li><li>**TAS** - Tasmania</li><li>**VIC** - Victoria</li></ul>
+          enum:
+            - ALL
+            - ACT
+            - NEM
+            - NSW
+            - QLD
+            - SA
+            - TAS
+            - VIC
+          type: string
+        isGenerator:
+          description: This flag determines whether the energy at this connection
+            point is to be treated as consumer load or as a generating unit(this may
+            include generator auxiliary loads). If absent defaults to false. <br>**Note:**
+            Only applicable for scheduled or semischeduled generators, does not indicate
+            on site generation by consumer
+          type: boolean
+        validFromDate:
+          description: The latest start date from which the constituent data sets
+            of this service point became valid
+          type: string
+        lastUpdateDateTime:
+          description: The date and time that the information for this service point
+            was modified
+          type: string
+        lastConsumerChangeDate:
+          description: The date on which the retailer was last changed for the service point
+          type: string
+        consumerProfile:
+          $ref: '#/components/schemas/EnergyServicePoint_consumerProfile'
+        distributionLossFactor:
+          $ref: '#/components/schemas/EnergyServicePointDetail_distributionLossFactor'
+        relatedParticipants:
+          items:
+            $ref: '#/components/schemas/EnergyServicePointDetail_relatedParticipants'
+          type: array
+        location:
+          $ref: '#/components/schemas/CommonPhysicalAddress'
+        meters:
+          description: The meters associated with the service point. This may be empty
+            where there are no meters physically installed at the service point
+          items:
+            $ref: '#/components/schemas/EnergyServicePointDetail_meters'
+          type: array
+        der:
+          $ref: '#/components/schemas/EnergyDerRecord'
+        adatree:
+          $ref: '#/components/schemas/Adatree'
+      required:
+        - distributionLossFactor
+        - jurisdictionCode
+        - lastUpdateDateTime
+        - location
+        - meters
+        - nationalMeteringId
+        - relatedParticipants
+        - servicePointClassification
+        - servicePointId
+        - servicePointStatus
+        - validFromDate
+    EnergyUsageRead:
+      properties:
+        servicePointId:
+          description: Tokenised ID of the service point to be used for referring
+            to the service point in the CDR API suite.  To be created in accordance
+            with CDR ID permanence requirements
+          type: string
+        registerId:
+          description: Register ID of the meter register where the meter reads are
+            obtained
+          type: string
+        registerSuffix:
+          description: Register suffix of the meter register where the meter reads
+            are obtained
+          type: string
+        meterId:
+          description: Meter id/serial number as it appears in customers bill. ID
+            permanence rules do not apply.
+          type: string
+        controlledLoad:
+          description: Indicates whether the energy recorded by this register is created
+            under a Controlled Load regime
+          type: boolean
+        readStartDate:
+          description: Date when the meter reads start in AEST and assumed to start
+            from 12:00 am AEST.
+          type: string
+        readEndDate:
+          description: Date when the meter reads end in AEST.  If absent then assumed
+            to be equal to readStartDate.  In this case the entry represents data
+            for a single date specified by readStartDate.
+          type: string
+        unitOfMeasure:
+          description: Unit of measure of the meter reads. Refer to Appendix B of
+            <a href='https://www.aemo.com.au/-/media/files/stakeholder_consultation/consultations/nem-consultations/2019/5ms-metering-package-2/final-determination/mdff-specification-nem12-nem13-v21-final-determination-clean.pdf?la=en&hash=03FCBA0D60E091DE00F2361AE76206EA'>MDFF
+            Specification NEM12 NEM13 v2.1</a> for a list of possible values.
+          type: string
+        readUType:
+          description: Specify the type of the meter read data
+          enum:
+            - basicRead
+            - intervalRead
+          type: string
+        basicRead:
+          $ref: '#/components/schemas/EnergyUsageRead_basicRead'
+        intervalRead:
+          $ref: '#/components/schemas/EnergyUsageRead_intervalRead'
+        adatree:
+          $ref: '#/components/schemas/Adatree'
+      required:
+        - readStartDate
+        - readUType
+        - registerSuffix
+        - servicePointId
+        - adatree
+      type: object
+      x-conditional:
+        - basicRead
+        - intervalRead
+    EnergyDerRecord:
+      properties:
+        servicePointId:
+          description: Tokenised ID of the service point to be used for referring
+            to the service point in the CDR API suite.  To be created in accordance
+            with CDR ID permanence requirements
+          type: string
+        approvedCapacity:
+          description: Approved small generating unit capacity as agreed with NSP
+            in the connection agreement, expressed in kVA. Value of 0 indicates no
+            DER record exists for the given servicePointId
+          type: number
+        availablePhasesCount:
+          description: The number of phases available for the installation of DER.
+            Acceptable values are 0, 1, 2 or 3. Value of 0 indicates no DER record
+            exists for the given servicePointId
+          maximum: 3
+          minimum: 0
+          type: integer
+        installedPhasesCount:
+          description: The number of phases that DER is connected to. Acceptable values
+            are 0, 1, 2 or 3. Value of 0 indicates no DER record exists for the given
+            servicePointId
+          maximum: 3
+          minimum: 0
+          type: integer
+        islandableInstallation:
+          description: For identification of small generating units designed with
+            the ability to operate in an islanded mode
+          type: boolean
+        hasCentralProtectionControl:
+          description: For DER installations where NSPs specify the need for additional
+            forms of protection above those inbuilt in an inverter.  If absent then
+            assumed to be false
+          type: boolean
+        protectionMode:
+          $ref: '#/components/schemas/EnergyDerRecord_protectionMode'
+        acConnections:
+          items:
+            $ref: '#/components/schemas/EnergyDerRecord_acConnections'
+          type: array
+      required:
+        - acConnections
+        - approvedCapacity
+        - availablePhasesCount
+        - installedPhasesCount
+        - islandableInstallation
+        - servicePointId
+        - adatree
+      type: object
+      x-conditional:
+        - protectionMode
+    EnergyAccountBaseV2:
+      properties:
+        accountId:
+          description: The ID of the account.  To be created in accordance with CDR
+            ID permanence requirements
+          type: string
+        accountNumber:
+          description: Optional identifier of the account as defined by the data holder.  This
+            must be the value presented on physical statements (if it exists) and
+            must not be used for the value of accountId
+          type: string
+        displayName:
+          description: An optional display name for the account if one exists or can
+            be derived.  The content of this field is at the discretion of the data
+            holder
+          type: string
+        openStatus:
+          description: Open or closed status for the account. If not present then
+            OPEN is assumed
+          enum:
+            - CLOSED
+            - OPEN
+          type: string
+        creationDate:
+          description: The date that the account was created or opened. Mandatory
+            if openStatus is OPEN
+          type: string
+          x-cds-type: DateString
+      required:
+        - accountId
+      type: object
+    EnergyAccountDetailV2:
+      allOf:
+        - $ref: '#/components/schemas/EnergyAccountBaseV2'
+        - $ref: '#/components/schemas/EnergyAccountDetailV2_allOf'
+    EnergyAccountDetailV3:
+      allOf:
+        - $ref: '#/components/schemas/EnergyAccountBaseV2'
+        - $ref: '#/components/schemas/EnergyAccountDetailV3_allOf'
+    EnergyPaymentSchedule:
+      properties:
+        amount:
+          description: Optional payment amount indicating that a constant payment
+            amount is scheduled to be paid (used in bill smooting scenarios)
+          type: string
+        paymentScheduleUType:
+          description: The type of object present in this response
+          enum:
+            - cardDebit
+            - directDebit
+            - manualPayment
+            - digitalWallet
+          type: string
+        cardDebit:
+          $ref: '#/components/schemas/EnergyPaymentSchedule_cardDebit'
+        directDebit:
+          $ref: '#/components/schemas/EnergyPaymentSchedule_directDebit'
+        digitalWallet:
+          $ref: '#/components/schemas/EnergyPaymentSchedule_digitalWallet'
+        manualPayment:
+          $ref: '#/components/schemas/EnergyPaymentSchedule_manualPayment'
+      required:
+        - paymentScheduleUType
+      type: object
+      x-conditional:
+        - cardDebit
+        - directDebit
+        - manualPayment
+        - digitalWallet
+    EnergyConcession:
+      example:
+        amount: amount
+        additionalInfoUri: additionalInfoUri
+        endDate: endDate
+        displayName: displayName
+        appliedTo:
+          - INVOICE
+        percentage: percentage
+        additionalInfo: additionalInfo
+        type: FIXED_AMOUNT
+        discountFrequency: discountFrequency
+        startDate: startDate
+      properties:
+        type:
+          description: Indicator of the method of concession calculation
+          enum:
+            - FIXED_AMOUNT
+            - FIXED_PERCENTAGE
+            - VARIABLE
+          type: string
+        displayName:
+          description: The display name of the concession
+          type: string
+        additionalInfo:
+          description: Display text providing more information on the concession
+            Mandatory if type is VARIABLE
+          type: string
+        additionalInfoUri:
+          description: Optional link to additional information regarding the concession
+          type: string
+        startDate:
+          description: Optional start date for the application of the concession
+          type: string
+        endDate:
+          description: Optional end date for the application of the concession
+          type: string
+        discountFrequency:
+          description: Conditional attribute for frequency at which a concession is
+            applied. Required if type is FIXED_AMOUNT or FIXED_PERCENTAGE. Formatted
+            according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)
+            (excludes recurrence syntax)
+          type: string
+        amount:
+          description: Conditional attribute for the amount of discount for the concession-
+            required if type is FIXED_AMOUNT
+          type: string
+        percentage:
+          description: Conditional attribute for the percentage of discount of concession
+            - required if type is FIXED_PERCENTAGE
+          type: string
+        appliedTo:
+          description: Array of ENUM's to specify what the concession applies to.
+            Multiple ENUM values can be provided. If absent, USAGE is assumed
+          items:
+            enum:
+              - INVOICE
+              - USAGE
+              - SERVICE_CHARGE
+              - CONTROLLED_LOAD
+            type: string
+          type: array
+      required:
+        - displayName
+        - type
+      type: object
+      x-conditional:
+        - additionalInfo
+        - discountFrequency
+        - amount
+        - percentage
+    EnergyInvoice:
+      properties:
+        accountId:
+          description: The ID of the account for which the invoice was issued
+          type: string
+        invoiceNumber:
+          description: The number assigned to this invoice by the energy Retailer
+          type: string
+        issueDate:
+          description: The date that the invoice was actually issued (as opposed to
+            generated or calculated)
+          type: string
+        dueDate:
+          description: The date that the invoice is due to be paid
+          type: string
+        period:
+          $ref: '#/components/schemas/EnergyInvoice_period'
+        invoiceAmount:
+          description: The net amount due for this invoice regardless of previous
+            balance
+          type: string
+        gstAmount:
+          description: The total GST amount for this invoice.  If absent then zero
+            is assumed
+          type: string
+        payOnTimeDiscount:
+          $ref: '#/components/schemas/EnergyInvoice_payOnTimeDiscount'
+        balanceAtIssue:
+          description: The account balance at the time the invoice was issued
+          type: string
+        servicePoints:
+          description: Array of service point IDs to which this invoice applies. May
+            be empty if the invoice contains no electricity usage related charges
+          items:
+            type: string
+          type: array
+        gas:
+          $ref: '#/components/schemas/EnergyInvoiceGasUsageCharges'
+        electricity:
+          $ref: '#/components/schemas/EnergyInvoiceElectricityUsageCharges'
+        accountCharges:
+          $ref: '#/components/schemas/EnergyInvoiceAccountCharges'
+        paymentStatus:
+          description: Indicator of the payment status for the invoice
+          enum:
+            - PAID
+            - PARTIALLY_PAID
+            - NOT_PAID
+          type: string
+        adatree:
+          $ref: '#/components/schemas/Adatree'
+      required:
+        - accountId
+        - balanceAtIssue
+        - invoiceNumber
+        - issueDate
+        - paymentStatus
+        - servicePoints
+        - adatree
+      type: object
+      x-conditional:
+        - period
+    EnergyInvoiceGasUsageCharges:
+      properties:
+        totalUsageCharges:
+          description: The aggregate total of usage charges for the period covered
+            by the invoice (exclusive of GST)
+          type: string
+        totalGenerationCredits:
+          description: The aggregate total of generation credits for the period covered
+            by the invoice (exclusive of GST)
+          type: string
+        totalOnceOffCharges:
+          description: The aggregate total of any once off charges arising from electricity
+            usage for the period covered by the invoice (exclusive of GST)
+          type: string
+        totalOnceOffDiscounts:
+          description: The aggregate total of any once off discounts or credits arising
+            from electricity usage for the period covered by the invoice (exclusive
+            of GST)
+          type: string
+        otherCharges:
+          description: Optional array of charges that may be part of the invoice (for
+            e.g. environmental charges for C&I consumers) (exclusive of GST)
+          items:
+            $ref: '#/components/schemas/EnergyInvoiceGasUsageCharges_otherCharges'
+          type: array
+        totalGst:
+          description: The total GST for all electricity usage charges.  If absent
+            then zero is assumed
+          type: string
+      required:
+        - totalGenerationCredits
+        - totalOnceOffCharges
+        - totalOnceOffDiscounts
+        - totalUsageCharges
+      type: object
+    EnergyInvoiceElectricityUsageCharges:
+      properties:
+        totalUsageCharges:
+          description: The aggregate total of usage charges for the period covered
+            by the invoice (exclusive of GST)
+          type: string
+        totalGenerationCredits:
+          description: The aggregate total of generation credits for the period covered
+            by the invoice (exclusive of GST)
+          type: string
+        totalOnceOffCharges:
+          description: The aggregate total of any once off charges arising from electricity
+            usage for the period covered by the invoice (exclusive of GST)
+          type: string
+        totalOnceOffDiscounts:
+          description: The aggregate total of any once off discounts or credits arising
+            from electricity usage for the period covered by the invoice (exclusive
+            of GST)
+          type: string
+        otherCharges:
+          description: Optional array of charges that may be part of the invoice (for
+            e.g. environmental charges for C&I consumers) (exclusive of GST)
+          items:
+            $ref: '#/components/schemas/EnergyInvoiceGasUsageCharges_otherCharges'
+          type: array
+        totalGst:
+          description: The total GST for all electricity usage charges.  If absent
+            then zero is assumed
+          type: string
+      required:
+        - totalGenerationCredits
+        - totalOnceOffCharges
+        - totalOnceOffDiscounts
+        - totalUsageCharges
+      type: object
+    EnergyInvoiceAccountCharges:
+      description: Object contain charges and credits related to electricity usage
+      properties:
+        totalCharges:
+          description: The aggregate total of account level charges for the period
+            covered by the invoice
+          type: string
+        totalDiscounts:
+          description: The aggregate total of account level discounts or credits for
+            the period covered by the invoice
+          type: string
+        totalGst:
+          description: The total GST for all account level charges.  If absent then
+            zero is assumed
+          type: string
+      required:
+        - totalCharges
+        - totalDiscounts
+      type: object
+    EnergyBillingTransaction:
+      properties:
+        accountId:
+          description: The ID of the account for which transaction applies
+          type: string
+        executionDateTime:
+          description: The date and time that the transaction occurred
+          type: string
+        gst:
+          description: The GST incurred in the transaction.  Should not be included
+            for credits or payments.  If absent zero is assumed
+          type: string
+        transactionUType:
+          description: Indicator of the type of transaction object present in this
+            record
+          enum:
+            - usage
+            - demand
+            - onceOff
+            - otherCharges
+            - payment
+          type: string
+        usage:
+          $ref: '#/components/schemas/EnergyBillingUsageTransaction'
+        demand:
+          $ref: '#/components/schemas/EnergyBillingDemandTransaction'
+        onceOff:
+          $ref: '#/components/schemas/EnergyBillingOnceOffTransaction'
+        otherCharges:
+          $ref: '#/components/schemas/EnergyBillingOtherTransaction'
+        payment:
+          $ref: '#/components/schemas/EnergyBillingPaymentTransaction'
+        adatree:
+          $ref: '#/components/schemas/Adatree'
+      required:
+        - accountId
+        - executionDateTime
+        - transactionUType
+        - adatree
+      type: object
+      x-conditional:
+        - usage
+        - onceOff
+        - payment
+    EnergyBillingUsageTransaction:
+      properties:
+        servicePointId:
+          description: The ID of the service point to which this transaction applies
+            if any
+          type: string
+        invoiceNumber:
+          description: The number of the invoice in which this transaction is included
+            if it has been issued
+          type: string
+        timeOfUseType:
+          description: The time of use type that the transaction applies to
+          enum:
+            - PEAK
+            - OFF_PEAK
+            - OFF_PEAK_DEMAND_CHARGE
+            - SHOULDER
+            - SHOULDER1
+            - SHOULDER2
+            - CONTROLLED_LOAD
+            - SOLAR
+            - AGGREGATE
+            - ALL_DAY
+          type: string
+        description:
+          description: Optional description of the transaction that can be used for
+            display purposes
+          type: string
+        isEstimate:
+          description: Flag indicating if the usage is estimated or actual.  True
+            indicates estimate.  False or absent indicates actual
+          type: boolean
+        startDate:
+          description: Date and time when the usage period starts
+          type: string
+        endDate:
+          description: Date and time when the usage period ends
+          type: string
+        measureUnit:
+          description: The measurement unit of rate. Assumed to be KWH if absent
+          enum:
+            - KWH
+            - KVA
+            - KVAR
+            - KVARH
+            - KW
+            - DAYS
+            - METER
+            - MONTH
+          type: string
+        usage:
+          description: The usage for the period in measure unit.  A negative value
+            indicates power generated
+          type: number
+        amount:
+          description: The amount charged or credited for this transaction prior to
+            any adjustments being applied.  A negative value indicates a credit
+          type: string
+        calculationFactors:
+          description: Additional calculation factors that inform the transaction
+          items:
+            $ref: '#/components/schemas/EnergyBillingUsageTransaction_calculationFactors'
+          type: array
+        adjustments:
+          description: Optional array of adjustments arising for this transaction
+          items:
+            $ref: '#/components/schemas/EnergyBillingUsageTransaction_adjustments'
+          type: array
+      required:
+        - amount
+        - endDate
+        - startDate
+        - timeOfUseType
+        - usage
+      type: object
+    EnergyBillingDemandTransaction:
+      properties:
+        servicePointId:
+          description: The ID of the service point to which this transaction applies
+            if any
+          type: string
+        invoiceNumber:
+          description: The number of the invoice in which this transaction is included
+            if it has been issued
+          type: string
+        timeOfUseType:
+          description: The time of use type that the transaction applies to
+          enum:
+            - PEAK
+            - OFF_PEAK
+            - OFF_PEAK_DEMAND_CHARGE
+            - SHOULDER
+            - SHOULDER1
+            - SHOULDER2
+            - CONTROLLED_LOAD
+            - SOLAR
+            - AGGREGATE
+            - ALL_DAY
+            - EXCESS
+          type: string
+        description:
+          description: Optional description of the transaction that can be used for
+            display purposes
+          type: string
+        isEstimate:
+          description: Flag indicating if the usage is estimated or actual.  True
+            indicates estimate.  False or absent indicates actual
+          type: boolean
+        startDate:
+          description: Date and time when the demand period starts
+          type: string
+        endDate:
+          description: Date and time when the demand period ends
+          type: string
+        rate:
+          description: The rate for the demand charge in kVA.  A negative value indicates
+            power generated
+          type: number
+        amount:
+          description: The amount charged or credited for this transaction prior to
+            any adjustments being applied.  A negative value indicates a credit
+          type: string
+        calculationFactors:
+          description: Additional calculation factors that inform the transaction
+          items:
+            $ref: '#/components/schemas/EnergyBillingUsageTransaction_calculationFactors'
+          type: array
+        adjustments:
+          description: Optional array of adjustments arising for this transaction
+          items:
+            $ref: '#/components/schemas/EnergyBillingUsageTransaction_adjustments'
+          type: array
+        measureUnit:
+          description: The measurement unit of rate. Assumed to be KVA if absent
+          enum:
+            - KWH
+            - KVA
+            - KVAR
+            - KVARH
+            - KW
+            - DAYS
+            - METER
+            - MONTH
+          type: string
+      required:
+        - amount
+        - endDate
+        - rate
+        - startDate
+        - timeOfUseType
+      type: object
+    EnergyBillingOnceOffTransaction:
+      properties:
+        servicePointId:
+          description: The ID of the service point to which this transaction applies
+            if any
+          type: string
+        invoiceNumber:
+          description: The number of the invoice in which this transaction is included
+            if it has been issued
+          type: string
+        amount:
+          description: The amount of the charge or credit.  A positive value indicates
+            a charge and a negative value indicates a credit
+          type: string
+        description:
+          description: A free text description of the item
+          type: string
+      required:
+        - amount
+        - description
+      type: object
+    EnergyBillingOtherTransaction:
+      properties:
+        servicePointId:
+          description: The ID of the service point to which this transaction applies
+            if any
+          type: string
+        invoiceNumber:
+          description: The number of the invoice in which this transaction is included
+            if it has been issued
+          type: string
+        startDate:
+          description: Optional start date for the application of the charge
+          type: string
+        endDate:
+          description: Optional end date for the application of the charge
+          type: string
+        type:
+          description: Type of charge. Assumed to be other if absent
+          enum:
+            - ENVIRONMENTAL
+            - REGULATED
+            - NETWORK
+            - METERING
+            - RETAIL_SERVICE
+            - RCTI
+            - OTHER
+          type: string
+        amount:
+          description: The amount of the charge
+          type: string
+        description:
+          description: A free text description of the item
+          type: string
+        calculationFactors:
+          description: Additional calculation factors that inform the transaction
+          items:
+            $ref: '#/components/schemas/EnergyBillingUsageTransaction_calculationFactors'
+          type: array
+        adjustments:
+          description: Optional array of adjustments arising for this transaction
+          items:
+            $ref: '#/components/schemas/EnergyBillingUsageTransaction_adjustments'
+          type: array
+      required:
+        - amount
+        - description
+      type: object
+    EnergyBillingPaymentTransaction:
+      properties:
+        amount:
+          description: The amount paid
+          type: string
+        method:
+          description: The method of payment
+          enum:
+            - DIRECT_DEBIT
+            - CARD
+            - TRANSFER
+            - BPAY
+            - CASH
+            - CHEQUE
+            - OTHER
+          type: string
+      required:
+        - amount
+        - method
+      type: object
+    EnergyServicePointList_data:
+      properties:
+        servicePoints:
+          items:
+            $ref: '#/components/schemas/EnergyServicePointDetail'
+          type: array
+      required:
+        - servicePoints
+      type: object
+    EnergyUsageList_data:
+      properties:
+        reads:
+          description: Array of meter reads sorted by NMI in ascending order followed
+            by readStartDate in descending order
+          items:
+            $ref: '#/components/schemas/EnergyUsageRead'
+          type: array
+      required:
+        - reads
+      type: object
+    EnergyInvoiceList_data:
+      properties:
+        invoices:
+          description: Array of invoices sorted by issue date in descending order
+          items:
+            $ref: '#/components/schemas/EnergyInvoice'
+          type: array
+      required:
+        - invoices
+      type: object
+    EnergyBillingList_data:
+      properties:
+        transactions:
+          description: Array of transactions sorted by date and time in descending
+            order
+          items:
+            $ref: '#/components/schemas/EnergyBillingTransaction'
+          type: array
+      required:
+        - transactions
+      type: object
+    ErrorList_meta:
+      description: Additional data for customised error codes
+      properties:
+        urn:
+          description: The CDR error code URN which the application-specific error
+            code extends. Mandatory if the error `code` is an application-specific
+            error rather than a standardised error code.
+          type: string
+      type: object
+      x-conditional:
+        - urn
+    ErrorList_errors:
+      properties:
+        code:
+          description: The code of the error encountered. Where the error is specific
+            to the respondent, an application-specific error code, expressed as a
+            string value. If the error is application-specific, the URN code that
+            the specific error extends must be provided in the meta object. Otherwise,
+            the value is the error code URN.
+          type: string
+        title:
+          description: A short, human-readable summary of the problem that MUST NOT
+            change from occurrence to occurrence of the problem represented by the
+            error code.
+          type: string
+        detail:
+          description: A human-readable explanation specific to this occurrence of
+            the problem.
+          type: string
+        meta:
+          $ref: '#/components/schemas/ErrorList_meta'
+      required:
+        - code
+        - detail
+        - title
+      type: object
+    SecuredCdsDataApiError:
+      properties:
+        code:
+          description: The code of the error encountered.
+          type: string
+          enum:
+            - BALANCE_REFRESH_ERROR
+            - CONSUMER_PRESENT_REFRESH_ERROR
+            - THROTTLED_BY_DATA_HOLDER_ERROR
+            - COLLECTION_ERROR
+        title:
+          description: A short, human-readable summary of the problem.
+          type: string
+        detail:
+          description: A human-readable explanation specific to this occurrence of
+            the problem.
+          type: string
+        retryAfter:
+          description: "'Retry-After' value if error code is 'THROTTLED_BY_DATA_HOLDER_ERROR', which can either be a http-date or delay in seconds, as provided by data holder. Please note this value is not always provided by data holders, in which case this field will be null."
+          type: string
+      required:
+        - code
+        - detail
+        - title
+        - cdrArrangementId
+      type: object
+    EnergyPlanDetail_allOf_meteringCharges:
+      properties:
+        displayName:
+          description: Display name of the charge
+          type: string
+        description:
+          description: Description of the charge
+          type: string
+        minimumValue:
+          description: Minimum value of the charge if the charge is a range or the
+            absolute value of the charge if no range is specified
+          type: string
+        maximumValue:
+          description: The upper limit of the charge if the charge could occur in
+            a range
+          type: string
+        period:
+          description: The charges that occur on a schedule indicates the frequency.
+            Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)
+            (excludes recurrence syntax)
+          type: string
+      required:
+        - displayName
+        - minimumValue
+      type: object
+    EnergyPlanContract_intrinsicGreenPower:
+      description: Describes intrinsic green power for the plan.  If present then
+        the plan includes a percentage of green power in the base plan. Should not
+        be present for gas contracts
+      properties:
+        greenPercentage:
+          description: Percentage of green power intrinsically included in the plan
+          type: string
+      required:
+        - greenPercentage
+      type: object
+    EnergyServicePoint_consumerProfile:
+      properties:
+        classification:
+          description: A code that defines the consumer class as defined in the National
+            Energy Retail Regulations, or in overriding Jurisdictional instruments
+          enum:
+            - BUSINESS
+            - RESIDENTIAL
+          type: string
+        threshold:
+          description: 'A code that defines the consumption threshold as defined in
+            the National Energy Retail Regulations, or in overriding Jurisdictional
+            instruments. Note the details of enumeration values below: <ul><li>**LOW**
+            - Consumption is less than the lower consumption threshold as defined
+            in the National Energy Retail Regulations</li><li>**MEDIUM** - Consumption
+            is equal to or greater than the lower consumption threshold, but less
+            than the upper consumption threshold, as defined in the National Energy
+            Retail Regulations</li><li>**HIGH** - Consumption is equal to or greater
+            than the upper consumption threshold as defined in the National Energy
+            Retail Regulations</li></ul>'
+          enum:
+            - LOW
+            - MEDIUM
+            - HIGH
+          type: string
+      type: object
+    EnergyServicePointDetail_distributionLossFactor:
+      properties:
+        code:
+          description: A code used to identify data loss factor for the service point
+            values.  Refer to AEMO distribution loss factor documents for each financial
+            year to interpret
+          type: string
+        description:
+          description: Description of the data loss factor code and value
+          type: string
+        lossValue:
+          description: The value associated with the loss factor code
+          type: string
+      required:
+        - code
+        - description
+        - lossValue
+      type: object
+    EnergyServicePointDetail_relatedParticipants:
+      properties:
+        party:
+          description: The name of the party/orginsation related to this service point
+          type: string
+        role:
+          description: 'The role performed by this participant in relation to the
+            service point. Note the details of enumeration values below: <ul><li>**FRMP**
+            - Financially Responsible Market Participant</li><li>**LNSP** - Local
+            Network Service Provider or Embedded Network Manager for child connection
+            points</li><li>**DRSP** - wholesale Demand Response and/or market ancillary
+            Service Provider and note that where it is not relevant for a NMI it will
+            not be included</li></ul>'
+          enum:
+            - FRMP
+            - LNSP
+            - DRSP
+          type: string
+      required:
+        - party
+        - role
+      type: object
+    EnergyServicePointDetail_specifications:
+      description: Technical characteristics of the meter
+      properties:
+        status:
+          description: 'A code to denote the status of the meter. Note the details
+            of enumeration values below: <ul><li>**CURRENT** -Applies when a meter
+            is current and not disconnected</li><li>**DISCONNECTED** - Applies when
+            a meter is present but has been remotely disconnected</li></ul>'
+          enum:
+            - CURRENT
+            - DISCONNECTED
+          type: string
+        installationType:
+          description: 'The metering Installation type code indicates whether the
+            metering installation has to be manually read. Note the details of enumeration
+            values below: <ul><li>**BASIC** - Accumulation Meter â€“ Type 6</li><li>**COMMS1**
+            - Interval Meter with communications â€“ Type 1</li><li>**COMMS2** - Interval
+            Meter with communications â€“ Type 2</li><li>**COMMS3** - Interval Meter
+            with communications â€“ Type 3</li><li>**COMMS4** - Interval Meter with
+            communications â€“ Type 4</li><li>**COMMS4C** - CT connected metering installation
+            that meets the minimum services specifications</li><li>**COMMS4D** - Whole
+            current metering installation that meets the minimum services specifications</li><li>**MRAM**
+            - Small customer metering installation â€“ Type 4A</li><li>**MRIM** - Manually
+            Read Interval Meter â€“ Type 5</li><li>**UMCP** - Unmetered Supply â€“ Type
+            7</li><li>**VICAMI** - A relevant metering installation as defined in
+            clause 9.9C of the NER</li><li>**NCONUML** - Non-contestable unmeter load
+            - Introduced as part of Global Settlement</li></ul>'
+          enum:
+            - BASIC
+            - COMMS1
+            - COMMS2
+            - COMMS3
+            - COMMS4
+            - COMMS4C
+            - COMMS4D
+            - MRAM
+            - MRIM
+            - PROF
+            - SAMPLE
+            - UMCP
+            - VICAMI
+            - NCOLNUML
+          type: string
+        manufacturer:
+          description: Free text field to identify the manufacturer of the installed
+            meter
+          type: string
+        model:
+          description: Free text field to identify the meter manufacturers designation
+            for the meter model
+          type: string
+        readType:
+          description: 'Code to denote the method and frequency of Meter Reading.
+            The value is formatted as follows: <ul><li>First Character = Remote (R)
+            or Manual (M)</li><li>Second Character = Mode: T = telephone W = wireless
+            P = powerline I = infra-red G = galvanic V = visual </li><li>Third Character
+            = Frequency of Scheduled Meter Readings: 1 = Twelve times per year 2 =
+            Six times per year 3 = Four times per year D = Daily or weekly</li><li>Optional
+            Fourth Character = to identify what interval length the meter is capable
+            of reading. This includes five, 15 and 30 minute granularity as the following:
+            A â€“ 5 minute B â€“ 15 minute C â€“ 30 minute D â€“ Cannot convert to 5 minute
+            (i.e. due to metering installation de-energised) M - Manually Read Accumulation
+            Meter</li></ul> For example, <ul><li>MV3 = Manual, Visual, Quarterly</li>
+            <li>MV3M = Manual, Visual, Quarterly, Manually Read Accumulation Meter</li>
+            <li>RWDC = Remote, Wireless, Daily, 30 minutes interval</li></ul>'
+          type: string
+        nextScheduledReadDate:
+          description: This date is the next scheduled meter read date (NSRD) if a
+            manual Meter Reading is required
+          type: string
+      required:
+        - installationType
+        - status
+      type: object
+    EnergyServicePointDetail_registers:
+      properties:
+        registerId:
+          description: Unique identifier of the register within this service point.  Is
+            not globally unique
+          type: string
+        registerSuffix:
+          description: Register suffix of the meter register where the meter reads
+            are obtained
+          type: string
+        averagedDailyLoad:
+          description: The energy delivered through a connection point or metering
+            point over an extended period normalised to a 'per day' basis (kWh). This
+            value is calculated annually.
+          type: number
+        registerConsumptionType:
+          description: Indicates the consumption type of register
+          enum:
+            - INTERVAL
+            - BASIC
+            - PROFILE_DATA
+            - ACTIVE_IMPORT
+            - ACTIVE
+            - REACTIVE_IMPORT
+            - REACTIVE
+          type: string
+        networkTariffCode:
+          description: The Network Tariff Code is a free text field containing a code
+            supplied and published by the local network service provider
+          type: string
+        unitOfMeasure:
+          description: The unit of measure for data held in this register
+          type: string
+        timeOfDay:
+          description: Code to identify the time validity of register contents
+          enum:
+            - ALLDAY
+            - INTERVAL
+            - PEAK
+            - BUSINESS
+            - SHOULDER
+            - EVENING
+            - OFFPEAK
+            - CONTROLLED
+            - DEMAND
+          type: string
+        multiplier:
+          description: Multiplier required to take a register value and turn it into
+            a value representing billable energy
+          type: number
+        controlledLoad:
+          description: Indicates whether the energy recorded by this register is created
+            under a Controlled Load regime
+          type: boolean
+        consumptionType:
+          description: 'Actual/Subtractive Indicator. Note the details of enumeration
+            values below: <ul><li>**ACTUAL** implies volume of energy actually metered
+            between two dates</li><li>**CUMULATIVE** indicates a meter reading for
+            a specific date. A second Meter Reading is required to determine the consumption
+            between those two Meter Reading dates</li></ul>'
+          enum:
+            - ACTUAL
+            - CUMULATIVE
+          type: string
+      required:
+        - registerConsumptionType
+        - registerId
+      type: object
+    EnergyServicePointDetail_meters:
+      properties:
+        meterId:
+          description: The meter ID uniquely identifies a meter for a given service
+            point.  It is unique in the context of the service point.  It is not globally
+            unique
+          type: string
+        specifications:
+          $ref: '#/components/schemas/EnergyServicePointDetail_specifications'
+        registers:
+          description: Usage data registers available from the meter. This may be
+            empty where there are no meters physically installed at the service point
+          items:
+            $ref: '#/components/schemas/EnergyServicePointDetail_registers'
+          type: array
+      required:
+        - meterId
+        - specifications
+      type: object
+    EnergyUsageRead_basicRead:
+      description: Mandatory if readUType is set to basicRead
+      properties:
+        quality:
+          default: ACTUAL
+          description: The quality of the read taken.  If absent then assumed to be
+            ACTUAL
+          enum:
+            - ACTUAL
+            - SUBSTITUTE
+            - FINAL_SUBSTITUTE
+          type: string
+        value:
+          description: Meter read value.  If positive then it means consumption, if
+            negative it means export
+          type: number
+      required:
+        - value
+      type: object
+    EnergyUsageRead_intervalRead_readQualities:
+      properties:
+        startInterval:
+          description: Start interval for read quality flag. First read begins at
+            1
+          type: integer
+        endInterval:
+          description: End interval for read quality flag
+          type: integer
+        quality:
+          description: The quality of the read taken
+          enum:
+            - SUBSTITUTE
+            - FINAL_SUBSTITUTE
+          type: string
+      required:
+        - endInterval
+        - quality
+        - startInterval
+      type: object
+    EnergyUsageRead_intervalRead:
+      description: Mandatory if readUType is set to intervalRead
+      properties:
+        readIntervalLength:
+          description: Read interval length in minutes. Required when interval-reads
+            query parameter equals FULL or MIN_30
+          type: integer
+        aggregateValue:
+          description: The aggregate sum of the interval read values. If positive
+            then it means net consumption, if negative it means net export
+          type: number
+        intervalReads:
+          description: Array of Interval read values. If positive then it means consumption,
+            if negative it means export. Required when interval-reads query parameter
+            equals FULL or  MIN_30.<br>Each read value indicates the read for the
+            interval specified by readIntervalLength beginning at midnight of readStartDate
+            (for example 00:00 to 00:30 would be the first reading in a 30 minute
+            Interval)
+          items:
+            type: number
+          type: array
+        readQualities:
+          description: ' Specifies quality of reads that are not ACTUAL.  For read
+            indices that are not specified, quality is assumed to be ACTUAL. If not
+            present, all quality of all reads are assumed to be actual. Required when
+            interval-reads query parameter equals FULL or MIN_30'
+          items:
+            $ref: '#/components/schemas/EnergyUsageRead_intervalRead_readQualities'
+          type: array
+      required:
+        - aggregateValue
+      type: object
+      x-conditional:
+        - readIntervalLength
+        - intervalReads
+        - readQualities
+    EnergyDerRecord_protectionMode:
+      description: Required only when the hasCentralProtectionAndControl flag is set
+        to true.  One or more of the object fields will be provided to describe the
+        protection modes in place
+      properties:
+        exportLimitKva:
+          description: Maximum amount of power (kVA) that may be exported from a connection
+            point to the grid, as monitored by a control / relay function. An absent
+            value indicates no limit
+          type: number
+        underFrequencyProtection:
+          description: Protective function limit in Hz.
+          type: number
+        underFrequencyProtectionDelay:
+          description: Trip delay time in seconds.
+          type: number
+        overFrequencyProtection:
+          description: Protective function limit in Hz.
+          type: number
+        overFrequencyProtectionDelay:
+          description: Trip delay time in seconds.
+          type: number
+        underVoltageProtection:
+          description: Protective function limit in V.
+          type: number
+        underVoltageProtectionDelay:
+          description: Trip delay time in seconds.
+          type: number
+        overVoltageProtection:
+          description: Protective function limit in V.
+          type: number
+        overVoltageProtectionDelay:
+          description: Trip delay time in seconds.
+          type: number
+        sustainedOverVoltage:
+          description: Sustained over voltage.
+          type: number
+        sustainedOverVoltageDelay:
+          description: Sustained Over voltage protection delay in seconds.
+          type: number
+        frequencyRateOfChange:
+          description: Rate of change of frequency trip point (Hz/s).
+          type: number
+        voltageVectorShift:
+          description: Trip angle in degrees.
+          type: number
+        interTripScheme:
+          description: Description of the form of inter-trip (e.g. 'from local substation').
+          type: string
+        neutralVoltageDisplacement:
+          description: Trip voltage.
+          type: number
+      type: object
+    EnergyDerRecord_derDevices:
+      properties:
+        deviceIdentifier:
+          description: Unique identifier for a single DER device or a group of DER
+            devices with the same attributes. Does not align with CDR ID permanence
+            standards
+          type: number
+        count:
+          description: Number of devices in the group of DER devices
+          type: integer
+        manufacturer:
+          description: The name of the device manufacturer. If absent then assumed
+            to be unknown
+          type: string
+        modelNumber:
+          description: The model number of the device. If absent then assumed to be
+            unknown
+          type: string
+        status:
+          description: Code used to indicate the status of the device. This will be
+            used to identify if an inverter is active or inactive or decommissioned
+          enum:
+            - ACTIVE
+            - INACTIVE
+            - DECOMMISSIONED
+          type: string
+        type:
+          description: Used to indicate the primary technology used in the DER device
+          enum:
+            - FOSSIL
+            - HYDRO
+            - WIND
+            - SOLAR_PV
+            - RENEWABLE
+            - GEOTHERMAL
+            - STORAGE
+            - OTHER
+          type: string
+        subtype:
+          description: Used to indicate the primary technology used in the DER device.
+            This field is also used to record for example the battery chemistry, or
+            the type of PV panel. It is also used to record if a battery is contained
+            in an electric vehicle connected in a vehicle-to-grid arrangement. If
+            absent then assumed to be other
+          type: string
+        nominalRatedCapacity:
+          description: Maximum output in kVA that is listed in the product specification
+            by the manufacturer. This refers to the capacity of each unit within the
+            device group. Default is 0 if value not known
+          type: number
+        nominalStorageCapacity:
+          description: Maximum storage capacity in kVAh. This refers to the capacity
+            of each storage module within the device group. Mandatory if type is equal
+            to STORAGE. Default is 0 if value not known
+          type: number
+      required:
+        - count
+        - deviceIdentifier
+        - nominalRatedCapacity
+        - type
+      type: object
+      x-conditional:
+        - nominalStorageCapacity
+    EnergyDerRecord_acConnections:
+      properties:
+        connectionIdentifier:
+          description: AC Connection ID as defined in the DER register.  Does not
+            align with CDR ID permanence standards
+          type: number
+        count:
+          description: Number of AC Connections in the group. For the suite of AC
+            Connections to be considered as a group, all of the AC Connections included
+            must have the same attributes
+          type: integer
+        equipmentType:
+          description: Indicates whether the DER device is connected via an inverter
+            (and what category of inverter it is) or not (e.g. rotating machine).
+            If absent, assume equipment type to be OTHER.
+          enum:
+            - INVERTER
+            - OTHER
+          type: string
+        manufacturerName:
+          description: The name of the inverter manufacturer. Mandatory if equipmentType
+            is INVERTER
+          type: string
+        inverterSeries:
+          description: The inverter series. Mandatory if equipmentType is INVERTER
+          type: string
+        inverterModelNumber:
+          description: The inverter model number. Mandatory if equipmentType is INVERTER
+          type: string
+        commissioningDate:
+          description: The date that the DER installation is commissioned
+          type: string
+        status:
+          description: Code used to indicate the status of the Inverter. This will
+            be used to identify if an inverter is active or inactive or decommissioned
+          enum:
+            - ACTIVE
+            - INACTIVE
+            - DECOMMISSIONED
+          type: string
+        inverterDeviceCapacity:
+          description: The rated AC output power that is listed in the product specified
+            by the manufacturer. Mandatory if equipmentType is INVERTER. Default is
+            0 if value not known
+          type: number
+        derDevices:
+          items:
+            $ref: '#/components/schemas/EnergyDerRecord_derDevices'
+          type: array
+      required:
+        - commissioningDate
+        - connectionIdentifier
+        - count
+        - derDevices
+        - status
+      type: object
+      x-conditional:
+        - manufacturerName
+        - inverterSeries
+        - inverterModelNumber
+        - inverterDeviceCapacity
+    EnergyAccountV2_allOf_planOverview:
+      description: Mandatory if openStatus is OPEN
+      properties:
+        displayName:
+          description: The name of the plan if one exists
+          type: string
+        startDate:
+          description: The start date of the applicability of this plan
+          type: string
+        endDate:
+          description: The end date of the applicability of this plan
+          type: string
+      required:
+        - startDate
+      type: object
+    EnergyAccountDetailV2_allOf_planDetail:
+      description: Detail on the plan applicable to this account. Mandatory if openStatus
+        is OPEN
+      properties:
+        fuelType:
+          description: The fuel types covered by the plan
+          enum:
+            - ELECTRICITY
+            - GAS
+            - DUAL
+          type: string
+        isContingentPlan:
+          description: Flag that indicates that the plan is contingent on the customer
+            taking up an alternate fuel plan from the same retailer (for instance,
+            if the fuelType is ELECTRICITY then a GAS plan from the same retailer
+            must be taken up). Has no meaning if the plan has a fuelType of DUAL.
+            If absent the value is assumed to be false
+          type: boolean
+        meteringCharges:
+          description: Charges for metering included in the plan
+          items:
+            $ref: '#/components/schemas/EnergyPlanDetail_allOf_meteringCharges'
+          type: array
+        gasContract:
+          description: "v2: Updated Gas Contract details"
+          allOf:
+            - $ref: '#/components/schemas/EnergyPlanContract'
+        electricityContract:
+          description: "v2: Updated Electricity Contract details"
+          allOf:
+            - $ref: '#/components/schemas/EnergyPlanContract'
+      required:
+        - fuelType
+      type: object
+      x-conditional:
+        - gasContract
+        - electricityContract
+    EnergyAccountDetailV3_allOf_planDetail:
+      description: "Detail on the plan applicable to this account. Mandatory if openStatus is OPEN. **v2 update: Contracts updated to V2 schemas**."
+      properties:
+        fuelType:
+          description: The fuel types covered by the plan
+          enum:
+            - ELECTRICITY
+            - GAS
+            - DUAL
+          type: string
+        isContingentPlan:
+          description: Flag indicating the plan is contingent on an alternate fuel plan from the same retailer (e.g., if fuelType is ELECTRICITY, a GAS plan must be taken up). No meaning if fuelType is DUAL. Assumed false if absent.
+          type: boolean
+        meteringCharges:
+          description: Charges for metering included in the plan
+          type: array
+          items:
+            $ref: '#/components/schemas/EnergyPlanDetail_allOf_meteringCharges'
+        gasContract:
+          description: "v2: Updated Gas Contract details"
+          $ref: '#/components/schemas/EnergyPlanContractV2'
+        electricityContract:
+          description: "v2: Updated Electricity Contract details"
+          $ref: '#/components/schemas/EnergyPlanContractV2'
+      required:
+        - fuelType
+      type: object
+    EnergyAccountDetailV2_allOf_authorisedContacts:
+      properties:
+        firstName:
+          description: For people with single names this field need not be present.
+            The single name should be in the lastName field
+          type: string
+        lastName:
+          description: For people with single names the single name should be in this
+            field
+          type: string
+        middleNames:
+          description: Field is mandatory but array may be empty
+          items:
+            type: string
+          type: array
+        prefix:
+          description: Also known as title or salutation. The prefix to the name (e.g.
+            Mr, Mrs, Ms, Miss, Sir, etc)
+          type: string
+        suffix:
+          description: Used for a trailing suffix to the name (e.g. Jr)
+          type: string
+      required:
+        - lastName
+      type: object
+    EnergyAccountDetailV2_allOf_plans:
+      properties:
+        nickname:
+          description: Optional display name for the plan provided by the customer
+            to help differentiate multiple plans
+          type: string
+        servicePointIds:
+          description: An array of servicePointIds, representing NMIs, that this account
+            is linked to
+          items:
+            type: string
+          type: array
+        planOverview:
+          $ref: '#/components/schemas/EnergyAccountV2_allOf_planOverview'
+        planDetail:
+          $ref: '#/components/schemas/EnergyAccountDetailV2_allOf_planDetail'
+        authorisedContacts:
+          description: An array of additional contacts that are authorised to act
+            on this account
+          items:
+            $ref: '#/components/schemas/EnergyAccountDetailV2_allOf_authorisedContacts'
+          type: array
+      required:
+        - servicePointIds
+      type: object
+      x-conditional:
+        - planOverview
+        - planDetail
+    EnergyAccountDetailV3_allOf_plans:
+      type: object
+      properties:
+        nickname:
+          description: Optional display name for the plan provided by the customer to help differentiate multiple plans
+          type: string
+        servicePointIds:
+          description: An array of servicePointIds, representing NMIs, that this account is linked to
+          type: array
+          items:
+            type: string
+        planOverview:
+          $ref: '#/components/schemas/EnergyAccountV2_allOf_planOverview'
+        planDetail:
+          $ref: '#/components/schemas/EnergyAccountDetailV3_allOf_planDetail'
+        authorisedContacts:
+          description: An array of additional contacts that are authorised to act on this account
+          type: array
+          items:
+            $ref: '#/components/schemas/EnergyAccountDetailV2_allOf_authorisedContacts'
+      required:
+        - servicePointIds
+    EnergyAccountDetailV2_allOf:
+      description: The array of plans containing service points and associated plan details
+      properties:
+        balance:
+          description: The current balance of the account.  A positive value indicates
+            that amount is owing to be paid.  A negative value indicates that the
+            account is in credit
+          type: string
+        plans:
+          description: The array of plans containing service points and associated
+            plan details
+          items:
+            $ref: '#/components/schemas/EnergyAccountDetailV2_allOf_plans'
+          type: array
+        paymentSchedules:
+          description: The array of agreed payment schedules
+          items:
+            $ref: '#/components/schemas/EnergyPaymentSchedule'
+          type: array
+        concessions:
+          description: Array may be empty if no concessions exist
+          items:
+            $ref: '#/components/schemas/EnergyConcession'
+          type: array
+        adatree:
+          $ref: '#/components/schemas/Adatree'
+      required:
+        - adatree
+      type: object
+    EnergyAccountDetailV3_allOf:
+      description: 'The array of plans containing service points and associated plan details (v2 schema: plans use V2 blocks)'
+      type: object
+      properties:
+        balance:
+          description: The current balance of the account. A positive value indicates that amount is owing to be paid. A negative value indicates that the account is in credit
+          type: string
+        plans:
+          description: The array of plans containing service points and associated plan details
+          type: array
+          items:
+            $ref: '#/components/schemas/EnergyAccountDetailV3_allOf_plans'
+        paymentSchedules:
+          description: The array of agreed payment schedules
+          type: array
+          items:
+            $ref: '#/components/schemas/EnergyPaymentSchedule'
+        concessions:
+          description: Array may be empty if no concessions exist
+          type: array
+          items:
+            $ref: '#/components/schemas/EnergyConcession'
+        adatree:
+          $ref: '#/components/schemas/Adatree'
+      required:
+        - adatree
+    EnergyPaymentSchedule_cardDebit:
+      description: Represents a regular credit card payment schedule. Mandatory if
+        paymentScheduleUType is set to cardDebit
+      properties:
+        cardScheme:
+          description: The type of credit card held on file
+          enum:
+            - VISA
+            - MASTERCARD
+            - AMEX
+            - DINERS
+            - OTHER
+            - UNKNOWN
+          type: string
+        paymentFrequency:
+          description: The frequency that payments will occur.  Formatted according
+            to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)
+            (excludes recurrence syntax)
+          type: string
+        calculationType:
+          description: The mechanism by which the payment amount is calculated.  Explanation
+            of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent,
+            static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding
+            balance for the account is paid per period</li><li>**CALCULATED** - Indicates
+            that the payment amount is variable and calculated using a pre-defined
+            algorithm</li></ul>
+          enum:
+            - STATIC
+            - BALANCE
+            - CALCULATED
+          type: string
+      required:
+        - calculationType
+        - cardScheme
+        - paymentFrequency
+      type: object
+    EnergyPaymentSchedule_directDebit:
+      description: Represents a regular direct debit from a specified bank account.
+        Mandatory if paymentScheduleUType is set to directDebit
+      properties:
+        isTokenised:
+          description: Flag indicating that the account details are tokenised and
+            cannot be shared.  False if absent
+          type: boolean
+        bsb:
+          description: The unmasked BSB for the account to be debited. Is expected
+            to be formatted as digits only with leading zeros included and no punctuation
+            or spaces.  Is required if isTokenised is absent or false
+          type: string
+        accountNumber:
+          description: The unmasked account number for the account to be debited.
+            Is expected to be formatted as digits only with leading zeros included
+            and no punctuation or spaces.  Is required if isTokenised is absent or
+            false
+          type: string
+        paymentFrequency:
+          description: The frequency that payments will occur.  Formatted according
+            to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)
+            (excludes recurrence syntax)
+          type: string
+        calculationType:
+          description: The mechanism by which the payment amount is calculated.  Explanation
+            of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent,
+            static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding
+            balance for the account is paid per period</li><li>**CALCULATED** - Indicates
+            that the payment amount is variable and calculated using a pre-defined
+            algorithm</li></ul>
+          enum:
+            - STATIC
+            - BALANCE
+            - CALCULATED
+          type: string
+      required:
+        - calculationType
+        - paymentFrequency
+      type: object
+      x-conditional:
+        - bsb
+        - accountNumber
+    EnergyPaymentSchedule_digitalWallet:
+      description: Represents a regular payment from a digital wallet. Mandatory if
+        paymentScheduleUType is set to digitalWallet
+      properties:
+        name:
+          description: The name assigned to the digital wallet by the owner of the
+            wallet, else the display name provided by the digital wallet provider
+          type: string
+        identifier:
+          description: The identifier of the digital wallet (dependent on type)
+          type: string
+        type:
+          description: The type of the digital wallet identifier
+          enum:
+            - EMAIL
+            - CONTACT_NAME
+            - TELEPHONE
+          type: string
+        provider:
+          description: The provider of the digital wallet
+          enum:
+            - PAYPAL_AU
+            - OTHER
+          type: string
+        paymentFrequency:
+          description: The frequency that payments will occur.  Formatted according
+            to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)
+            (excludes recurrence syntax)
+          type: string
+        calculationType:
+          description: The mechanism by which the payment amount is calculated.  Explanation
+            of values are as follows:<br/><ul><li>**STATIC** - Indicates a consistent,
+            static amount, per payment</li><li>**BALANCE** - Indicates that the outstanding
+            balance for the account is paid per period</li><li>**CALCULATED** - Indicates
+            that the payment amount is variable and calculated using a pre-defined
+            algorithm</li></ul>
+          enum:
+            - STATIC
+            - BALANCE
+            - CALCULATED
+          type: string
+      required:
+        - calculationType
+        - identifier
+        - name
+        - paymentFrequency
+        - provider
+        - type
+      type: object
+    EnergyPaymentSchedule_manualPayment:
+      description: Represents a manual payment schedule where the customer pays in
+        response to a delivered statement. Mandatory if paymentScheduleUType is set
+        to manualPayment
+      properties:
+        billFrequency:
+          description: The frequency with which a bill will be issued.  Formatted
+            according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)
+            (excludes recurrence syntax)
+          type: string
+      required:
+        - billFrequency
+      type: object
+    EnergyInvoice_period:
+      description: Object containing the start and end date for the period covered
+        by the invoice.  Mandatory if any usage or demand based charges are included
+        in the invoice
+      properties:
+        startDate:
+          description: The start date of the period covered by this invoice
+          type: string
+        endDate:
+          description: The end date of the period covered by this invoice
+          type: string
+      required:
+        - endDate
+        - startDate
+      type: object
+    EnergyInvoice_payOnTimeDiscount:
+      description: A discount for on time payment
+      properties:
+        discountAmount:
+          description: The amount that will be discounted if the invoice is paid by
+            the date specified
+          type: string
+        gstAmount:
+          description: The GST amount that will be discounted if the invoice is paid
+            by the date specified.  If absent then zero is assumed
+          type: string
+        date:
+          description: The date by which the invoice must be paid to receive the pay
+            on time discount
+          type: string
+      required:
+        - date
+        - discountAmount
+      type: object
+    EnergyInvoiceGasUsageCharges_otherCharges:
+      properties:
+        type:
+          description: Type of charge. Assumed to be other if absent
+          enum:
+            - ENVIRONMENTAL
+            - REGULATED
+            - NETWORK
+            - METERING
+            - RETAIL_SERVICE
+            - RCTI
+            - OTHER
+          type: string
+        amount:
+          description: The aggregate total of charges for this item (exclusive of
+            GST)
+          type: string
+        description:
+          description: A free text description of the type of charge
+          type: string
+      required:
+        - amount
+        - description
+      type: object
+    EnergyBillingUsageTransaction_calculationFactors:
+      properties:
+        value:
+          description: The value of the calculation factor
+          type: number
+        type:
+          description: The type of the calculation factor
+          enum:
+            - DLF
+            - MLF
+          type: string
+      required:
+        - type
+        - value
+      type: object
+    EnergyBillingUsageTransaction_adjustments:
+      properties:
+        amount:
+          description: The amount of the adjustment
+          type: string
+        description:
+          description: A free text description of the adjustment
+          type: string
+      required:
+        - amount
+        - description
+      type: object
+  #-------------------------------
+  # Reusable parameters
+  #-------------------------------
+  parameters:
+    #-------------------------------
+    # Query parameters
+    #-------------------------------
+    QueryAccountIds:
+      name: accountIds
+      in: query
+      required: false
+      description: Used to filter results on the accountId field.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific accountIds to obtain data for
+          example: 30370f1b-cd27-4d56-b56d-beb49fc9aa48
+    QueryAccountIsOwned:
+      name: isOwned
+      in: query
+      description: Filters accounts based on whether they are owned by the authorised customer.
+        True for owned accounts, false for unowned accounts and absent for all accounts
+      schema:
+        type: boolean
+        example: true
+    QueryAccountOpenStatus:
+      name: openStatus
+      in: query
+      description: Used to filter results according to open/closed status. Values can be OPEN, CLOSED
+      required: false
+      schema:
+        type: string
+        example: OPEN
+        enum:
+          - OPEN
+          - CLOSED
+    QueryPage:
+      name: page
+      in: query
+      description: Page of results to request (standard pagination)
+      schema:
+        type: integer
+        format: int32
+        default: 1
+        minimum: 1
+        example: 1
+    QueryPageSize:
+      name: pageSize
+      in: query
+      description: Page size to request
+      schema:
+        type: integer
+        format: int32
+        default: 25
+        minimum: 1
+        maximum: 1000
+        example: 25
+    QueryProductCategory:
+      name: productCategories
+      in: query
+      description: Used to filter results on the productCategory field applicable to accounts.
+        Any one of the valid values for this field can be supplied. If absent then all accounts returned.
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          example: BUSINESS_LOANS
+          enum:
+            - BUSINESS_LOANS
+            - BUY_NOW_PAY_LATER
+            - CRED_AND_CHRG_CARDS
+            - LEASES
+            - MARGIN_LOANS
+            - OVERDRAFTS
+            - PERS_LOANS
+            - REGULATED_TRUST_ACCOUNTS
+            - RESIDENTIAL_MORTGAGES
+            - TERM_DEPOSITS
+            - TRADE_FINANCE
+            - TRAVEL_CARDS
+            - TRANS_AND_SAVINGS_ACCOUNTS
+    QueryUseCaseIds:
+      name: useCaseIds
+      in: query
+      description: Used to filter results on the useCaseId field.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific UseCaseIds to obtain data for
+          example: HOME_LOAN
+    QueryCdrArrangementIds:
+      name: cdrArrangementIds
+      in: query
+      description: Used to filter results on the cdrArrangementId field.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific cdrArrangementIds to obtain data for
+          example: 30370f1b-cd27-4d56-b56d-beb49fc9aa48
+    QueryConsentIds:
+      name: consentIds
+      in: query
+      description: Used to filter results on the consentId field.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific consentIds to obtain data for
+          example: 30370f1b-cd27-4d56-b56d-beb49fc9aa48
+    QueryConsumerIds:
+      name: consumerIds
+      in: query
+      description: Used to filter results on the consumerId field.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific consumerIds to obtain data for
+          example: 30370f1b-cd27-4d56-b56d-beb49fc9aa48
+    QueryDataHolderBrandIds:
+      name: dataHolderBrandIds
+      in: query
+      description: Used to filter results on the dataHolderBrandId field.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific dataHolderBrandIds to obtain data for
+          example: 30370f1b-cd27-4d56-b56d-beb49fc9aa48
+    QueryProductIds:
+      name: productIds
+      in: query
+      description: IDs of the specific products
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific productId to obtain data for
+          example: [f632041c-d7c8-4679-a165-aa406cd62b13]
+    QueryTransactionOldestRetrievalTime:
+      name: oldestRetrievalTime
+      in: query
+      description: Constrain the transaction history request to transactions with retrieval time at or after this date/time.
+        Format is aligned to DateTimeString common type.
+      schema:
+        type: string
+        example: "2012-12-25T15:43:00-08:00"
+    QueryTransactionNewestRetrievalTime:
+      name: newestRetrievalTime
+      in: query
+      description: Constrain the transaction history request to transactions with retrieval time at or before this date/time.
+        Format is aligned to DateTimeString common type.
+      schema:
+        type: string
+        example: "2012-12-25T15:43:00-08:00"
+    QueryTransactionNewestTime:
+      name: newestTime
+      in: query
+      description: Constrain the transaction history request to transactions with
+        effective time at or before this date/time. Format is aligned to DateTimeString common type.
+      schema:
+        type: string
+        example: "2012-12-25T15:43:00-08:00"
+    QueryTransactionOldestTime:
+      name: oldestTime
+      in: query
+      description: Constrain the transaction history request to transactions with
+        effective time at or after this date/time. If absent defaults to newest-time
+        minus 90 days.  Format is aligned to DateTimeString common type
+      schema:
+        type: string
+        example: "2012-12-25T15:43:00-08:00"
+    QueryTransactionStatuses:
+      name: statuses
+      in: query
+      description: Used to filter results by status.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific transaction status to obtain data for
+          example: [POSTED]
+    QueryTransactionTypes:
+      name: types
+      in: query
+      description: Used to filter results on the type field.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific types to obtain data for
+          example: FEE
+    QueryTransactionMinimumAmount:
+      name: minimumAmount
+      in: query
+      description: Used to filter results on the amount field
+      schema:
+        type: number
+        example: 100
+    QueryTransactionMaximumAmount:
+      name: maximumAmount
+      in: query
+      description: Used to filter results on the amount field
+      schema:
+        type: number
+        example: 300
+    QueryPayeeTypes:
+      name: types
+      in: query
+      description: Used to filter results on the payee type field.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific types to obtain data for
+          example: BILLER
+    QueryPayeeIds:
+      name: payeeIds
+      in: query
+      required: false
+      description: Used to filter results on the payeeId field.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific payeeIds to obtain data for
+          example: 30370f1b-cd27-4d56-b56d-beb49fc9aa48
+    QueryCustomerUTypes:
+      name: customerUTypes
+      in: query
+      description: Used to filter results on the customerUType field applicable to customers.
+        Any one of the valid values for this field can be supplied.
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          example: person
+          enum:
+            - person
+            - organisation
+    QueryServicePointIds:
+      name: servicePointIds
+      in: query
+      description: Used to filter results on the servicePointId field.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific servicePointIds to filter the result list by
+    QueryInvoiceIds:
+      name: invoiceIds
+      in: query
+      description: Used to filter results on the invoiceId field.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific invoiceIds to filter the result list by
+    QueryBillingIds:
+      name: billingIds
+      in: query
+      description: Used to filter results on the billingId field.
+      schema:
+        type: array
+        items:
+          type: string
+          description: Array of specific billingId to filter the result list by
+    HeaderConsumerAuthDate:
+      name: Adatree-Consumer-Auth-Date
+      in: header
+      description: The time when the customer last logged in. Mandatory for consumer present calls using a Machine token.
+      schema:
+        type: string
+        example: 'Tue, 11 Sep 2012 19:43:31 GMT'
+    HeaderConsumerIpAddress:
+      name: Adatree-Consumer-Ip-Address
+      in: header
+      description: The consumer's original IP address. Mandatory for consumer present calls using a Machine token.
+      schema:
+        type: string
+        example: 127.0.0.1
+    HeaderUserAgent:
+      name: Adatree-Consumer-User-Agent
+      in: header
+      description: User Agent header of the consumer facing application. Mandatory for consumer present calls using a Machine token.
+      schema:
+        type: string
+    QueryOldestDate:
+      name: oldestDate
+      in: query
+      description: |
+        Constrain the request to records with effective date at or after this date. If absent defaults to newest-date minus 24 months.
+      schema:
+        type: string
+        example: "2022-12-31"
+    QueryNewestDate:
+      name: newestDate
+      in: query
+      description: |
+        Constrain the request to records with effective date at or before this date. If absent defaults to current date.
+      schema:
+        type: string
+        example: "2022-12-31"
+  #-------------------------------
+  # Reusable responses
+  #-------------------------------
+  responses:
+    401Unauthorised:
+      description: Unauthorised
+    403Forbidden:
+      description: Forbidden
+    404NotFound:
+      description: The specified resource was not found.
+    400BadRequest:
+      description: Request is invalid
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorList'
+    429RateLimited:
+      description: Ratelimit reached
+    GenericError:
+      description: An error occurred.
+      content:
+        application/json:
+          schema:
+            type: string
+            example: something went wrong

--- a/draft/data.yaml
+++ b/draft/data.yaml
@@ -1436,6 +1436,7 @@ components:
       required:
         - feeType
         - name
+        - feeMethodUType
       properties:
         name:
           type: string


### PR DESCRIPTION
## Summary
- Stages CDR Banking v1.36.0-aligned breaking changes in `draft/banking.yaml` (v2.0.1 → v3.0.0) and `draft/data.yaml` (v1.4.0 → v2.0.0) for review before promotion to root specs.
- `BankingProductFee`, `BankingProductDiscount`, `BankingProductRateTierV3` lose their deprecated flat fields; `minimumValueString` becomes required on rate tiers.
- `BankingProductDetail.instalments` added (additive, data spec only). Unused `QueryPlan*` parameter defs removed from data spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)